### PR TITLE
Compatibility with svg.path >= 4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+cython
+dxfgrabber
+nngt
+numpy
+pint
+scipy
+setuptools
+shapely
+svg.path

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pint
 scipy
 setuptools
 shapely
-svg.path
+svg.path >= 4


### PR DESCRIPTION
Updated PyNCulture to work with svg.path >= 4.
Added requirements.txt.