### PR TITLE
Fix geometry error in growth

### DIFF
--- a/examples/neurons/chandelier-cell.py
+++ b/examples/neurons/chandelier-cell.py
@@ -94,7 +94,8 @@ ds.set_kernel_status(kernel)
 # create neurons
 
 n = ds.create_neurons(n=num_neurons, params=neuron_params,
-                      axon_params=axon_params, dendrites_params=dend_params,
+                      axon_params=axon_params,
+                      dendrites_params=dend_params,
                       num_neurites=3)
 
 
@@ -147,7 +148,7 @@ lb = {
     "use_van_pelt": False,
     #~ 'res_branching_threshold': np.inf,
     "use_uniform_branching": True,
-    "uniform_branching_rate": 0.05*cph, 
+    "uniform_branching_rate": 0.04*cph, 
     "lateral_branching_angle_mean": 45.*deg
 }
 
@@ -158,22 +159,22 @@ ds.simulate(10*day)
 ds.plot.plot_neurons(show=True)
 
 
-end_branching = { "use_flpl_branching": False, "use_uniform_branching": False, "use_van_pelt": True, "T": 60*day}
+end_branching = {
+    "use_flpl_branching": False,
+    "use_uniform_branching": False,
+    "use_van_pelt": True,
+    "T": 60*day
+}
+
 ds.set_object_properties(n, axon_params=end_branching, dendrites_params=end_branching)
 
 ds.simulate(20*day)
 
 print(ds.get_kernel_status("time"))
+
+ds.plot.plot_dendrogram(n.axon, show=False, vertical_diam_frac=0.45)
 ds.plot.plot_neurons(show=True)
 
 ds.io.save_to_swc("chandelier-cell.swc", gid=n, resolution=50)
 
-tree = n.axon.get_tree()
-
-plt.axis('off')
-fig.suptitle("")
-plt.tight_layout()
-plt.show()
-tree.show_dendrogram()
-
-print("Asymmetry of axon:", ds.structure.tree_asymmetry(n[0].axon))
+print("Asymmetry of axon:", ds.morphology.tree_asymmetry(n.axon))

--- a/examples/neurons/purkinje.py
+++ b/examples/neurons/purkinje.py
@@ -123,8 +123,8 @@ if __name__ == '__main__':
 
     ds.simulate(6*day)
     ds.plot.plot_dendrogram(neuron.dendrites["dendrite_1"],
-                            ignore_diameter=True, aspect_ratio=0.2,
-                            show=False)
+                            ignore_diameter=True, aspect_ratio=0.5,
+                            vertical_diam_frac=0.45, show=False)
     ds.plot.plot_neurons()
 
     neuron.set_properties(dendrites_params={
@@ -137,6 +137,6 @@ if __name__ == '__main__':
     ds.simulate(20.*day)
     ds.plot.plot_dendrogram(neuron.dendrites["dendrite_1"],
                             ignore_diameter=True, aspect_ratio=0.2,
-                            show=False)
+                            vertical_diam_frac=0.45, show=False)
     ds.plot.plot_neurons()
     ds.plot.plot_recording(rec)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scipy
 setuptools
 shapely
 svg.path >= 4
+neurom

--- a/src/elements/GrowthCone.hpp
+++ b/src/elements/GrowthCone.hpp
@@ -99,6 +99,7 @@ class GrowthCone : public TopologicalNode,
     double proba_down_move_; // proba of going down if bottom out of reach
     double scale_up_move_;   // maximal height that GC can cross upwards
     double retraction_time_;
+    double old_angle_;
 
     space_tree_map current_neighbors_;
 

--- a/src/pymodule/dense/plot/plot_structures.py
+++ b/src/pymodule/dense/plot/plot_structures.py
@@ -397,7 +397,7 @@ def plot_dendrogram(neurite, axis=None, show_node_id=False,
     tips = set(tree.tips)
 
     # if diameter is ignored, set all values to default_diam
-    default_diam = 0.2*vspace
+    default_diam = vertical_diam_frac*vspace
 
     if ignore_diameter:
         tree.root.diameter = default_diam


### PR DESCRIPTION
This PR corrects the fact that growth cones could previously turn more than 90° and thus potentially overlap with themselves.
It also corrects some of the neuron examples and improves the dendrogram plot when diameter is ignored.