### PR TITLE
Speed modulation

### DIFF
--- a/docs/dense_theme/static/dense_theme.css
+++ b/docs/dense_theme/static/dense_theme.css
@@ -46,6 +46,10 @@ ul.globaltoc {
     margin: 0;
 }
 
+ul.simple p {
+    margin-bottom: 0;
+}
+
 img.logo {
     margin: 1ex 0 1em 0;
 }

--- a/docs/user/extension_component.rst
+++ b/docs/user/extension_component.rst
@@ -29,6 +29,12 @@ simply elongates with a constant speed ``speed_growth_cone`` for all timesteps.
 
 For the detailed implementation, see :cpp:class:`growth::CstExtensionModel`.
 
+.. note::
+
+    The constant speed of this elongation model can still be changed
+    if the "speed decay" feature is used at the neurite level.
+    See :ref:`speed-decay` and the ``speed_decay`` parameter.
+
 
 Gaussian fluctuations
 =====================
@@ -43,6 +49,12 @@ In the model, the fluctuations occur randomly, with zero correlation and a
 standard deviation ``speed_variance`` (@todo change the name).
 
 For the detailed implementation, see :cpp:class:`growth::GFluctExtensionModel`.
+
+.. note::
+
+    The average speed of this elongation model can be changed
+    if the "speed decay" feature is used at the neurite level.
+    See :ref:`speed-decay` and the ``speed_decay`` parameter.
 
 
 Resource-based elongation
@@ -132,6 +144,16 @@ with:
 
 For the detailed implementation, see
 :cpp:class:`growth::ResourceBasedExtensionModel`.
+
+.. note::
+
+    Because it intrisically accounts for the number of growth cones
+    in the neurite, this model is not compatible (or at least it is not
+    affected) by the "speed decay" feature: changes in the number of
+    growth cones will only change based on the parameters discussed
+    above and do not depend on the ``speed_decay`` parameter.
+    See :ref:`speed-decay` for more information about this feature
+    and how it can be used with the other elongation models.
 
 
 References

--- a/docs/user/growth_models.rst
+++ b/docs/user/growth_models.rst
@@ -163,15 +163,18 @@ Lateral branching models can be turned on or off using the
 neurite parameters. 
 @TODO : Why two parameters and what is the difference ?
 
+
 Growth cones
 ============
+
+.. _gc-models:
 
 Generic properties
 ------------------
 
 The parameters of the growth cones can also be set through :func:`~dense.set_object_properties`, either through the ``params`` argument, to
 set the properties of all growth cones in the neuron, or separately through
-the ``axon_params`` or ``dendrite_params` arguments.
+the ``axon_params`` or ``dendrite_params`` arguments.
 
 The main properties are:
 
@@ -192,8 +195,45 @@ The main properties are:
 * ``speed_growth_cone``, the average extension speed of the growth cone (this
   value can be modified by specific properties of extension models, see below).
 
-.. _gc-models:
 
+.. _speed-decay:
+
+Influence of the neurite
+------------------------
+
+Growth cone are not isolated units but interact through the common
+architecture of their neurite.
+This can be seen for instance through changes in the speed of individual
+growth cones as their number increases.
+
+A typical way of accounting for this fact is through an ad hoc change
+of the speed of the growth cones according to the following equation:
+
+.. math::
+
+    v(t) = v_0 n(t)^{-s_d}
+
+where:
+
+* :math:`v(t)` is the speed of a growth cone at time :math:`t`
+* :math:`v_0` is the original speed when a single growth cone is present
+* :math:`n(t)` is the number of growth cone supported by the neurite at
+  time :math:`t`
+* :math:`s_d` is the "speed decay" factor (available through the
+  ``speed_decay``)
+
+This feature is available for all extension components except the
+``resource-based`` (see :ref:`extension-component`).
+
+The resource-based model, on the other hand, does not require this ad
+hoc feature since the speed of the growth cones directly depend on the
+amount of resource available to each cone, and that they are
+intrinsically competing for this resource.
+Thus, the resource-based model provides a mechanistic approach to the
+same phenomenon.
+
+
+.. _elongation-models:
 
 Elongation models
 -----------------

--- a/src/elements/GrowthCone.hpp
+++ b/src/elements/GrowthCone.hpp
@@ -88,10 +88,6 @@ class GrowthCone : public TopologicalNode,
     double delta_angle_;
     double sensing_angle_;
     bool sensing_angle_set_;
-    double avg_speed_;
-    double local_avg_speed_;
-    double speed_variance_;
-    double local_speed_variance_;
     double duration_retraction_; // duration of a retraction period (seconds)
     double proba_retraction_;    // proba of retracting when stuck
     double retracting_todo_;     // duration left to retract
@@ -158,6 +154,8 @@ class GrowthCone : public TopologicalNode,
     // extension
     void compute_module(double substep);
     virtual void compute_speed(mtPtr rnd_engine, double substep) = 0;
+    virtual void update_speed(double update_factor) = 0;
+    virtual double get_max_speed() = 0;
 
     void init_filopodia();
 
@@ -185,7 +183,7 @@ class GrowthCone : public TopologicalNode,
     virtual void set_status(const statusMap &status);
     virtual void get_status(statusMap &status) const;
     void update_kernel_variables();
-    void update_growth_properties(const std::string &area_name);
+    virtual void update_growth_properties(const std::string &area_name) = 0;
     void update_filopodia();
 };
 

--- a/src/elements/Neurite.hpp
+++ b/src/elements/Neurite.hpp
@@ -157,6 +157,8 @@ class Neurite : public std::enable_shared_from_this<Neurite>
     void add_cone(GCPtr);
     void add_node(NodePtr);
 
+    void update_gc_speed();
+
     bool walk_tree(NodeProp &np) const;
     simple_gc_range active_gc_range() const;
     joined_gc_range gc_range() const;
@@ -200,6 +202,7 @@ class Neurite : public std::enable_shared_from_this<Neurite>
     std::string neurite_type_;
     double taper_rate_; // diameter thinning with distance
     double min_diameter_;
+    double gc_speed_decay_;
 
     // competition
     bool use_critical_resource_;

--- a/src/libgrowth/growth_names.cpp
+++ b/src/libgrowth/growth_names.cpp
@@ -65,7 +65,7 @@ const std::string branching_proba_default("branching_proba_default");
 
 const std::string critical_pull("critical_pull");
 
-const std::string decay_factor("decay_factor");
+const std::string memory_decay_factor("memory_decay_factor");
 const std::string dendrite_angles("dendrite_angles");
 const std::string dendrite_diameter("dendrite_diameter");
 const std::string description("description");
@@ -149,6 +149,7 @@ const std::string soma_radius("soma_radius");
 const std::string somatropic_factor("somatropic_factor");
 const std::string somatropic_mode("somatropic_mode");
 const std::string somatropic_scale("somatropic_scale");
+const std::string speed_decay_factor("speed_decay_factor");
 const std::string speed_growth_cone("speed_growth_cone");
 const std::string speed_ratio_retraction("speed_ratio_retraction");
 const std::string speed_variance("speed_variance");

--- a/src/libgrowth/growth_names.hpp
+++ b/src/libgrowth/growth_names.hpp
@@ -74,11 +74,11 @@ extern const std::string diameter_eta_exp;
 
 
 #define BRANCHING_PROBA_DEFAULT 0.05
-#define AXON_DIAMETER 6.
-#define DENDRITE_DIAMETER 6.
-#define SOMA_RADIUS 8.
-#define THINNING_RATIO 0.005 // lose 1 micrometer every 200 micrometers
-#define MIN_DIAMETER 0.1     // diameter when a gc stops growing [micrometers]
+#define AXON_DIAMETER 2.
+#define DENDRITE_DIAMETER 2.
+#define SOMA_RADIUS 5.
+#define THINNING_RATIO 0.002 // lose 1 micrometer every 500 micrometers
+#define MIN_DIAMETER 0.05     // diameter when a gc stops growing [micrometers]
 #define DIAMETER_RATIO_AVG 1.
 #define DIAM_RATIO_STD 0.02 // deviation from identical diameters on split
 #define DIAMETER_ETA_EXP 2.67
@@ -147,11 +147,12 @@ extern const std::string points_per_circle;
 // common
 extern const std::string persistence_length;
 extern const std::string rigidity_factor;
+extern const std::string speed_decay_factor;
 extern const std::string speed_growth_cone;
 extern const std::string speed_variance;
 
 // memory-based steering
-extern const std::string decay_factor;
+extern const std::string memory_decay_factor;
 
 // SRF steering
 extern const std::string somatropic_factor;

--- a/src/models/complete_gc_model.hpp
+++ b/src/models/complete_gc_model.hpp
@@ -155,6 +155,8 @@ GrowthConeModel<ElType, SteerMethod, DirSelMethod>::create_gc_model(
 
     gc->dir_selector_ = std::make_shared<DirSelMethod>(gc, nullptr);
 
+    gc->update_growth_properties(gc->current_area_);
+
     return gc;
 }
 

--- a/src/models/complete_gc_model.hpp
+++ b/src/models/complete_gc_model.hpp
@@ -153,9 +153,10 @@ GrowthConeModel<ElType, SteerMethod, DirSelMethod>::create_gc_model(
 
     gc->steerer_ = std::make_shared<SteerMethod>(gc, nullptr);
 
-    gc->dir_selector_ = std::make_shared<DirSelMethod>(gc, nullptr);
-
+    // update growth properties before direction selector
     gc->update_growth_properties(gc->current_area_);
+
+    gc->dir_selector_ = std::make_shared<DirSelMethod>(gc, nullptr);
 
     return gc;
 }
@@ -402,6 +403,8 @@ void GrowthConeModel<ElType, SteerMethod,
     {
         // just update local speed
         elongator_->update_local_speed(1.);
+        // and set default sensing angle
+        move_.sigma_angle = sensing_angle_;
     }
 }
 

--- a/src/models/complete_gc_model.hpp
+++ b/src/models/complete_gc_model.hpp
@@ -30,6 +30,9 @@
 #include "extension_interface.hpp"
 #include "steering_interface.hpp"
 
+// spatial
+#include "Area.hpp"
+
 
 namespace growth
 {
@@ -76,6 +79,9 @@ class GrowthConeModel : public virtual GrowthCone
                 double angle) override final;
 
     void compute_speed(mtPtr rnd_engine, double substep) override final;
+    void update_growth_properties(const std::string &area_name) override final;
+    inline void update_speed(double update_factor) override final;
+    inline double get_max_speed() override final;
 
     void
     compute_direction_probabilities(std::vector<double> &directions_weights,
@@ -109,6 +115,9 @@ GrowthConeModel<ElType, SteerMethod, DirSelMethod>::GrowthConeModel(
     const std::string &model)
     : GrowthCone(model)
 {
+    // only 'initial models' are directly created, other are cloned, so
+    // we don't need to get the area.
+    //~ update_growth_properties(current_area_);
 }
 
 
@@ -269,8 +278,7 @@ void GrowthConeModel<ElType, SteerMethod, DirSelMethod>::after_split()
 
 
 /**
- * @brief prepare the growth cone for a split.
- * @todo
+ * @brief set the growth cone status
  */
 template <class ElType, class SteerMethod, class DirSelMethod>
 void GrowthConeModel<ElType, SteerMethod, DirSelMethod>::set_status(
@@ -280,7 +288,7 @@ void GrowthConeModel<ElType, SteerMethod, DirSelMethod>::set_status(
     GrowthCone::set_status(status);
 
     // then set the models
-    elongator_->set_status(status);
+    bool speed = elongator_->set_status(status);
     steerer_->set_status(status);
 
     // direction selector may need to access all the properties
@@ -292,9 +300,21 @@ void GrowthConeModel<ElType, SteerMethod, DirSelMethod>::set_status(
     // update the status and set dire_selector
     base_status.insert(status.begin(), status.end());
     dir_selector_->set_status(base_status);
+
+    // check whether the sensing angle or speed was updated
+    double sa_tmp;
+    bool b_sa = get_param(status, names::sensing_angle, sa_tmp);
+
+    if (b_sa or speed)
+    {
+        update_growth_properties(current_area_);
+    }
 }
 
 
+/**
+ * @brief get the growth cone status
+ */
 template <class ElType, class SteerMethod, class DirSelMethod>
 void GrowthConeModel<ElType, SteerMethod, DirSelMethod>::get_status(
     statusMap &status) const
@@ -319,6 +339,9 @@ void GrowthConeModel<ElType, SteerMethod, DirSelMethod>::get_status(
 }
 
 
+/**
+ * @brief get a state variable
+ */
 template <class ElType, class SteerMethod, class DirSelMethod>
 double GrowthConeModel<ElType, SteerMethod, DirSelMethod>::get_state(
     const std::string &observable) const
@@ -341,6 +364,66 @@ double GrowthConeModel<ElType, SteerMethod, DirSelMethod>::get_state(
     }
 
     return value;
+}
+
+
+/**
+ * @brief update growth properties
+ */
+template <class ElType, class SteerMethod, class DirSelMethod>
+void GrowthConeModel<ElType, SteerMethod,
+                     DirSelMethod>::update_growth_properties(
+                         const std::string &area_name)
+{
+    // update the growth properties depending on the area
+    AreaPtr area = kernel().space_manager.get_area(area_name);
+
+    // test if the GC is in any Area
+    if (area != nullptr)
+    {
+        current_area_ = area_name;
+
+        // speed and sensing angle may vary
+        move_.sigma_angle =
+            std::min(sensing_angle_ *
+                     area->get_property(names::sensing_angle),
+                     max_sensing_angle_);
+
+        elongator_->update_local_speed(
+            area->get_property(names::speed_growth_cone));
+
+        // substrate affinity depends on the area
+        filopodia_.substrate_affinity =
+            area->get_property(names::substrate_affinity);
+    }
+    else
+    {
+        // just update local speed
+        elongator_->update_local_speed(1.);
+    }
+}
+
+
+/**
+ * @brief update local speed
+ */
+template <class ElType, class SteerMethod, class DirSelMethod>
+void GrowthConeModel<ElType, SteerMethod,
+                     DirSelMethod>::update_speed(
+                         double update_factor)
+{
+    elongator_->update_speed(update_factor);
+}
+
+
+/**
+ * @brief get max speed
+ */
+template <class ElType, class SteerMethod, class DirSelMethod>
+double GrowthConeModel<ElType, SteerMethod,
+                     DirSelMethod>::get_max_speed()
+{
+    return elongator_->get_max_speed();
 }
 
 } // namespace growth

--- a/src/models/extension_cst.hpp
+++ b/src/models/extension_cst.hpp
@@ -36,33 +36,52 @@ class CstExtensionModel : public virtual ExtensionModel
 {
   protected:
     double speed_growth_cone_;
+    double local_avg_speed_;
 
   public:
     CstExtensionModel(GCPtr gc, NeuritePtr neurite)
         : ExtensionModel(gc, neurite)
-        , speed_growth_cone_(SPEED_GROWTH_CONE){};
+        , speed_growth_cone_(SPEED_GROWTH_CONE)
+        , local_avg_speed_(SPEED_GROWTH_CONE){};
 
     CstExtensionModel(const CstExtensionModel &copy) = delete;
 
     CstExtensionModel(const CstExtensionModel &copy, GCPtr gc,
                       NeuritePtr neurite)
         : ExtensionModel(copy, gc, neurite)
-        , speed_growth_cone_(copy.speed_growth_cone_){};
+        , speed_growth_cone_(copy.speed_growth_cone_)
+        , local_avg_speed_(copy.local_avg_speed_){};
 
     double compute_speed(mtPtr rnd_engine, double substep) override final
     {
-        return speed_growth_cone_;
+        return local_avg_speed_;
     };
 
-    virtual void set_status(const statusMap &status) override final
+    bool set_status(const statusMap &status) override final
     {
-        get_param(status, names::speed_growth_cone, speed_growth_cone_);
+        return get_param(status, names::speed_growth_cone,
+                         speed_growth_cone_);
     };
 
-    virtual void get_status(statusMap &status) const override final
+    void get_status(statusMap &status) const override final
     {
         set_param(status, names::speed_growth_cone, speed_growth_cone_,
                   "micrometer / minute");
+    };
+
+    void update_speed(double speed_factor) override final
+    {
+        speed_growth_cone_ *= speed_factor;
+    };
+
+    void update_local_speed(double area_factor) override final
+    {
+        local_avg_speed_ = speed_growth_cone_ * area_factor;
+    };
+
+    double get_max_speed() const override final
+    {
+        return local_avg_speed_;
     };
 };
 

--- a/src/models/extension_cst.hpp
+++ b/src/models/extension_cst.hpp
@@ -71,7 +71,10 @@ class CstExtensionModel : public virtual ExtensionModel
 
     void update_speed(double speed_factor) override final
     {
+        double area_factor  = local_avg_speed_ / speed_growth_cone_;
+
         speed_growth_cone_ *= speed_factor;
+        local_avg_speed_    = speed_growth_cone_ * area_factor;
     };
 
     void update_local_speed(double area_factor) override final

--- a/src/models/extension_gfluct.cpp
+++ b/src/models/extension_gfluct.cpp
@@ -57,9 +57,19 @@ double GFluctExtensionModel::compute_speed(mtPtr rnd_engine, double substep)
 }
 
 
+/**
+ * @brief Update growth cone average speed.
+ * This function updates the average speed, e.g. because the number
+ * of growth cones sustained by the neurite changed.
+ * Since the average speed changed, the local speed must also be
+ * updated.
+ */
 void GFluctExtensionModel::update_speed(double speed_factor)
 {
+    double area_factor = local_speed_ / speed_gc_avg_;
+
     speed_gc_avg_ *= speed_factor;
+    local_speed_   = speed_gc_avg_ * area_factor;
 }
 
 

--- a/src/models/extension_gfluct.cpp
+++ b/src/models/extension_gfluct.cpp
@@ -30,7 +30,9 @@ namespace growth
 GFluctExtensionModel::GFluctExtensionModel(GCPtr gc, NeuritePtr neurite)
     : ExtensionModel(gc, neurite)
     , speed_gc_avg_(SPEED_GROWTH_CONE)
+    , local_speed_(SPEED_GROWTH_CONE)
     , speed_gc_std_(SPEED_GROWTH_CONE) // std = mean
+    , local_std_(SPEED_GROWTH_CONE)
 {
     normal_ = std::normal_distribution<double>(0, 1);
 }
@@ -40,7 +42,9 @@ GFluctExtensionModel::GFluctExtensionModel(const GFluctExtensionModel &copy,
                                            GCPtr gc, NeuritePtr neurite)
     : ExtensionModel(copy, gc, neurite)
     , speed_gc_avg_(copy.speed_gc_avg_)
+    , local_speed_(copy.local_speed_)
     , speed_gc_std_(copy.speed_gc_std_)
+    , local_std_(copy.local_std_)
 {
     normal_ = std::normal_distribution<double>(0, 1);
 }
@@ -48,20 +52,40 @@ GFluctExtensionModel::GFluctExtensionModel(const GFluctExtensionModel &copy,
 
 double GFluctExtensionModel::compute_speed(mtPtr rnd_engine, double substep)
 {
-    return speed_gc_avg_ +
-           speed_gc_std_ * sqrt(substep) * normal_(*(rnd_engine).get());
+    return local_speed_ +
+           local_std_ * sqrt(substep) * normal_(*(rnd_engine).get());
 }
 
 
-void GFluctExtensionModel::set_status(const statusMap &status)
+void GFluctExtensionModel::update_speed(double speed_factor)
+{
+    speed_gc_avg_ *= speed_factor;
+}
+
+
+void GFluctExtensionModel::update_local_speed(double area_factor)
+{
+    local_speed_ = speed_gc_avg_ * area_factor;
+    local_std_   = speed_gc_std_ / area_factor;
+}
+
+
+double GFluctExtensionModel::get_max_speed() const
+{
+    return local_speed_ + 5. * local_std_;
+}
+
+
+bool GFluctExtensionModel::set_status(const statusMap &status)
 {
     double std;
-    bool b;
+    bool bspeed, bstd;
 
-    get_param(status, names::speed_growth_cone, speed_gc_avg_);
+    bspeed = get_param(status, names::speed_growth_cone, speed_gc_avg_);
 
-    b = get_param(status, names::speed_variance, std);
-    if (b)
+    bstd = get_param(status, names::speed_variance, std);
+
+    if (bstd)
     {
         if (std < 0)
         {
@@ -71,6 +95,8 @@ void GFluctExtensionModel::set_status(const statusMap &status)
 
         speed_gc_std_ = std;
     }
+
+    return bspeed + bstd;
 }
 
 

--- a/src/models/extension_gfluct.hpp
+++ b/src/models/extension_gfluct.hpp
@@ -33,7 +33,9 @@ class GFluctExtensionModel : public virtual ExtensionModel
 {
   protected:
     double speed_gc_avg_;
+    double local_speed_;
     double speed_gc_std_;
+    double local_std_;
 
     std::normal_distribution<double> normal_;
 
@@ -44,8 +46,11 @@ class GFluctExtensionModel : public virtual ExtensionModel
                          NeuritePtr neurite);
 
     double compute_speed(mtPtr rnd_engine, double substep) override final;
+    void update_speed(double speed_factor) override final;
+    void update_local_speed(double area_factor) override final;
+    double get_max_speed() const override final;
 
-    virtual void set_status(const statusMap &status) override final;
+    virtual bool set_status(const statusMap &status) override final;
 
     virtual void get_status(statusMap &status) const override final;
 };

--- a/src/models/extension_interface.hpp
+++ b/src/models/extension_interface.hpp
@@ -87,6 +87,10 @@ class ExtensionModel
 
     virtual double compute_speed(mtPtr rnd_engine, double substep) = 0;
 
+    virtual void update_speed(double speed_factor) = 0;
+    virtual void update_local_speed(double area_factor) = 0;
+    virtual double get_max_speed() const = 0;
+
     void get_observables(std::vector<std::string> &obs) const
     {
         obs.insert(obs.end(), observables_.begin(), observables_.end());
@@ -94,11 +98,12 @@ class ExtensionModel
 
     virtual void prepare_for_split(){};
     virtual void after_split(){};
+
     virtual double get_state(const std::string &observable) const
     {
         return std::nan("");
     };
-    virtual void set_status(const statusMap &status) = 0;
+    virtual bool set_status(const statusMap &status) = 0;
     virtual void get_status(statusMap &status) const = 0;
 };
 

--- a/src/models/extension_resource_based.cpp
+++ b/src/models/extension_resource_based.cpp
@@ -53,6 +53,8 @@ ResourceBasedExtensionModel::ResourceBasedExtensionModel(GCPtr gc,
     , branching_proba_(CRITICAL_BRANCHING_PROBA)
     , weight_diameter_(CRITICAL_WEIGHT_DIAMETER)
     , weight_centrifugal_(CRITICAL_WEIGHT_CENTRIFUGAL)
+    , area_factor_(1.)
+    , inv_area_factor_(1.)
 {
     observables_.push_back("resource");
     consumption_rate_ = use_ratio_ + 1. / leakage_;
@@ -83,6 +85,8 @@ ResourceBasedExtensionModel::ResourceBasedExtensionModel(
     , branching_proba_(copy.branching_proba_)
     , weight_diameter_(copy.weight_diameter_)
     , weight_centrifugal_(copy.weight_centrifugal_)
+    , area_factor_(copy.area_factor_)
+    , inv_area_factor_(copy.inv_area_factor_)
 {
     normal_  = std::normal_distribution<double>(0, 1);
     uniform_ = std::uniform_real_distribution<double>(0., 1.);
@@ -170,16 +174,35 @@ double ResourceBasedExtensionModel::compute_speed(mtPtr rnd_engine,
     // if it's over the elongation threshold the neurite will extend
     if (stored_ < retraction_th_)
     {
-        speed =
-            retraction_factor_ * (stored_ - retraction_th_) / retraction_th_;
+        speed = inv_area_factor_ * retraction_factor_ *
+                (stored_ - retraction_th_) / retraction_th_;
     }
     else if (stored_ >= elongation_th_)
     {
-        speed = elongation_factor_ * (stored_ - elongation_th_) /
-                (stored_ + elongation_th_);
+        speed = area_factor_ * elongation_factor_ *
+                (stored_ - elongation_th_) / (stored_ + elongation_th_);
     }
 
     return speed;
+}
+
+
+void ResourceBasedExtensionModel::update_speed(double speed_factor)
+{
+    elongation_factor_ *= speed_factor;
+}
+
+
+void ResourceBasedExtensionModel::update_local_speed(double area_factor)
+{
+    area_factor_     = area_factor;
+    inv_area_factor_ = 1. / area_factor;
+}
+
+
+double ResourceBasedExtensionModel::get_max_speed() const
+{
+    return area_factor_ * elongation_factor_;
 }
 
 
@@ -276,13 +299,33 @@ void ResourceBasedExtensionModel::printinfo() const
 }
 
 
-void ResourceBasedExtensionModel::set_status(const statusMap &status)
+bool ResourceBasedExtensionModel::set_status(const statusMap &status)
 {
     // state parameters
     get_param(status, names::resource, stored_);
 
     // speed-related stuff
-    get_param(status, names::res_elongation_factor, elongation_factor_);
+    double speed;
+    bool bs, be;
+
+    bs = get_param(status, names::speed_growth_cone, speed);
+
+    be = get_param(status, names::res_elongation_factor, elongation_factor_);
+
+    if (bs and be)
+    {
+        throw std::runtime_error("In the resource-based model, please "
+                                 "use `elongation_factor` and "
+                                 "`retraction_factor` instead of "
+                                 "`speed_growth_cone`.");
+    }
+    else if (bs)
+    {
+        printf("In the resource-based model, please use "
+               "`elongation_factor` and `retraction_factor` instead of "
+               "`speed_growth_cone`.");
+    }
+
     get_param(status, names::res_retraction_factor, retraction_factor_);
     get_param(status, names::res_elongation_threshold, elongation_th_);
     get_param(status, names::res_retraction_threshold, retraction_th_);
@@ -305,6 +348,8 @@ void ResourceBasedExtensionModel::set_status(const statusMap &status)
 #ifndef NDEBUG
     printinfo();
 #endif
+
+    return false;
 }
 
 

--- a/src/models/extension_resource_based.cpp
+++ b/src/models/extension_resource_based.cpp
@@ -187,6 +187,13 @@ double ResourceBasedExtensionModel::compute_speed(mtPtr rnd_engine,
 }
 
 
+/**
+ * @brief Update growth cone average speed.
+ * This function updates the average speed, e.g. because the number
+ * of growth cones sustained by the neurite changed.
+ * Since the area factor is stored in this model, we do not need to
+ * update the local speed (there is no such value).
+ */
 void ResourceBasedExtensionModel::update_speed(double speed_factor)
 {
     elongation_factor_ *= speed_factor;

--- a/src/models/extension_resource_based.hpp
+++ b/src/models/extension_resource_based.hpp
@@ -60,6 +60,8 @@ class ResourceBasedExtensionModel : public virtual ExtensionModel
     double retraction_th_;
     double branching_th_;
     double branching_proba_;
+    double area_factor_;
+    double inv_area_factor_;
 
     std::uniform_real_distribution<double> uniform_;
     std::normal_distribution<double> normal_;
@@ -75,7 +77,10 @@ class ResourceBasedExtensionModel : public virtual ExtensionModel
     void after_split() override;
     void reset_res_demand();
 
-    double compute_speed(mtPtr rnd_engine, double substep) override;
+    double compute_speed(mtPtr rnd_engine, double substep) override final;
+    void update_speed(double speed_factor) override final;
+    void update_local_speed(double area_factor) override final;
+    double get_max_speed() const override final;
 
     void compute_res_received(double substep);
     double compute_CR(mtPtr rnd_engine, double substep, double step_length,
@@ -89,7 +94,7 @@ class ResourceBasedExtensionModel : public virtual ExtensionModel
     double get_speed() const;
 
     // status
-    void set_status(const statusMap &) override;
+    bool set_status(const statusMap &) override;
     void get_status(statusMap &) const override;
     virtual double get_state(const std::string &observable) const override;
 };

--- a/src/models/steering_memory_based.cpp
+++ b/src/models/steering_memory_based.cpp
@@ -35,7 +35,7 @@ MemBasedSteeringModel::MemBasedSteeringModel(GCPtr gc, NeuritePtr neurite)
     : SteeringModel(gc, neurite)
     , memory_angle_(fmod(gc->get_state("angle"), 2 * M_PI))
     , rigidity_factor_(1.)
-    , decay_factor_(0.9)
+    , memory_decay_factor_(0.9)
 {
     if (memory_angle_ < -M_PI)
     {
@@ -53,7 +53,7 @@ MemBasedSteeringModel::MemBasedSteeringModel(const MemBasedSteeringModel &copy,
     : SteeringModel(copy, gc, neurite)
     , memory_angle_(fmod(gc->get_state("angle"), 2 * M_PI))
     , rigidity_factor_(copy.rigidity_factor_)
-    , decay_factor_(copy.decay_factor_)
+    , memory_decay_factor_(copy.memory_decay_factor_)
 {
     if (memory_angle_ < -M_PI)
     {
@@ -88,7 +88,7 @@ void MemBasedSteeringModel::compute_direction_probabilities(
     // - third, compute segment volume
     double volume = M_PI * radius * radius * rodlen;
     // - then update through volume-weighted algorithm
-    double decay = pow(decay_factor_, rodlen);
+    double decay = pow(memory_decay_factor_, rodlen);
     memory_angle_ =
         (volume * current_angle + decay * memory_angle_) / (volume + decay);
 
@@ -172,16 +172,16 @@ void MemBasedSteeringModel::set_status(const statusMap &status)
         rigidity_factor_ = rf;
     }
 
-    b = get_param(status, names::decay_factor, md);
+    b = get_param(status, names::memory_decay_factor, md);
     if (b)
     {
         if (md < 0)
         {
-            throw std::invalid_argument("`" + names::decay_factor +
+            throw std::invalid_argument("`" + names::memory_decay_factor +
                                         "` must be positive.");
         }
 
-        decay_factor_ = md;
+        memory_decay_factor_ = md;
     }
 }
 
@@ -189,7 +189,7 @@ void MemBasedSteeringModel::set_status(const statusMap &status)
 void MemBasedSteeringModel::get_status(statusMap &status) const
 {
     set_param(status, names::rigidity_factor, rigidity_factor_, "");
-    set_param(status, names::decay_factor, decay_factor_, "");
+    set_param(status, names::memory_decay_factor, memory_decay_factor_, "");
 }
 
 } // namespace growth

--- a/src/models/steering_memory_based.hpp
+++ b/src/models/steering_memory_based.hpp
@@ -34,7 +34,7 @@ class MemBasedSteeringModel : public virtual SteeringModel
   private:
     double memory_angle_;    // priviledged direction
     double rigidity_factor_; // "strength" of the memory's influence
-    double decay_factor_;    // decay of a segment's influence after 1 um
+    double memory_decay_factor_;    // decay of a segment's influence after 1 um
 
   public:
     MemBasedSteeringModel(GCPtr gc, NeuritePtr neurite);

--- a/src/pymodule/dense/_pygrowth.pyx
+++ b/src/pymodule/dense/_pygrowth.pyx
@@ -1079,8 +1079,8 @@ def get_default_properties(obj, property_name=None, settables_only=True,
         ctype = _to_bytes("recorder")
     else:
         raise RuntimeError("Unknown object : '" + obj + "'. "
-                           "Candidates are 'recorder' and all entries in "
-                           "get_models.")
+                           "Candidates are 'recorder', 'neuron', "
+                           "'neurite', and all entries in get_models.")
 
     get_defaults_(cname, ctype, b"default", detailed, default_params)
     status = _statusMap_to_dict(default_params)

--- a/src/pymodule/dense/_pygrowth.pyx
+++ b/src/pymodule/dense/_pygrowth.pyx
@@ -1039,9 +1039,10 @@ def get_default_properties(obj, property_name=None, settables_only=True,
     Parameters
     ----------
     obj : :obj:`str` or :class:`Model`.
-        Name of the object, among "recorder", "neuron", "neurite", or
-        "growth_cone", or a model, either as a string (e.g. "cst_rw_wrc") or
-        as a :class:`Model` object returned by :func:`generate_model`.
+        Name of the object, among "recorder", "neuron", "neurite",
+        "axon", or "growth_cone", or a model, either as a string
+        (e.g. "cst_rw_wrc") or as a :class:`Model` object returned by
+        :func:`generate_model`.
     property_name : str, optional (default: None)
         Name of the property that should be queried. By default, the full
         dictionary is returned.
@@ -1071,6 +1072,8 @@ def get_default_properties(obj, property_name=None, settables_only=True,
 
     if obj in gc_models:
         ctype = _to_bytes("growth_cone")
+    elif obj == "growth_cone":
+        ctype = _to_bytes("growth_cone")
     elif obj == "neuron":
         ctype = _to_bytes("neuron")
     elif obj in ["axon", "dendrite", "neurite"]:
@@ -1080,7 +1083,8 @@ def get_default_properties(obj, property_name=None, settables_only=True,
     else:
         raise RuntimeError("Unknown object : '" + obj + "'. "
                            "Candidates are 'recorder', 'neuron', "
-                           "'neurite', and all entries in get_models.")
+                           "'neurite', 'axon', and all entries in "
+                           "get_models.")
 
     get_defaults_(cname, ctype, b"default", detailed, default_params)
     status = _statusMap_to_dict(default_params)

--- a/src/pymodule/dense/morphology/connections.py
+++ b/src/pymodule/dense/morphology/connections.py
@@ -165,8 +165,8 @@ def generate_network(source_neurons=None, target_neurons=None,
         raise RuntimeError('Cannot create a network without any neurons '
                            'or environment.')
 
-    network = NetClass(population=population, shape=shape, positions=positions,
-                       multigraph=multigraph)
+    network = NetClass(population=population, shape=shape,
+                       positions=positions, multigraph=multigraph)
 
     num_synapses = len(edges)
 
@@ -180,9 +180,8 @@ def generate_network(source_neurons=None, target_neurons=None,
     if distances is not None:
         data["distance"] = np.array(distances)
 
-    data["weight"] = np.repeat(default_synaptic_strength, num_synapses)
-
-    network.new_edges(edges, attributes=data)
+    network.new_edges(edges, attributes=data,
+                      unit_strength=default_synaptic_strength)
 
     return network
 

--- a/src/pymodule/dense/morphology/graph.py
+++ b/src/pymodule/dense/morphology/graph.py
@@ -153,7 +153,7 @@ class SpatialMultiNetwork(object):
 
         self._nodes.update(np.ravel(edge_list))
 
-        enum = self.edge_nb
+        enum = self._edge_nb
 
         for i, e in enumerate(edge_list):
             connection = tuple(e)
@@ -487,7 +487,8 @@ class SpatialNetwork(_BaseNetwork):
 
         return edge
 
-    def new_edges(self, edge_list, attributes=None, unit_strength=1., **kwargs):
+    def new_edges(self, edge_list, attributes=None, unit_strength=1.,
+                  **kwargs):
         '''
         Add a list of edges to the network.
 

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -112,7 +112,7 @@ def test_branching():
         mean.append(np.mean(Dt))
 
         # 99% confidence interval for a Poisson distribution gives 2.576
-        er.append(2.576*mean[-1]/np.sqrt(len(Dt)))
+        er.append(2.576/rate/np.sqrt(len(Dt)))
         Nb.append(len(Dt))
 
     mean_merr = np.subtract(mean, er)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -53,14 +53,22 @@ def test_2neuron_network(plot=False):
     ds.simulate(0.45*day)
 
     net = ds.morphology.generate_network(method="spines",
+                                         spine_density=1./um**2,
                                          max_spine_length=4.*um)
-
-    if plot:
-        ds.plot.plot_neurons(neurons, show_neuron_id=True)
 
     assert net.node_nb() == num_neurons, "Incorrect node number in the network"
     assert net.edge_nb() == 1, "Incorrect number of edges in the network"
     assert net.get_edge_attributes(name="weight")[0] > 1, "Incorrect weight"
+
+    net = ds.morphology.generate_network(method="intersections",
+                                         default_synaptic_strength=2.)
+
+    assert net.node_nb() == num_neurons, "Incorrect node number in the network"
+    assert net.edge_nb() == 1, "Incorrect number of edges in the network"
+    assert net.get_edge_attributes(name="weight")[0] == 2, "Incorrect weight"
+
+    if plot:
+        ds.plot.plot_neurons(neurons, show_neuron_id=True)
 
 
 def test_network(plot=False):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -175,7 +175,8 @@ def test_persistence():
             "taper_rate": 0.,
         }
 
-        gids = ds.create_neurons(n=num_neurons, num_neurites=1, params=params)
+        gids = ds.create_neurons(n=num_neurons, num_neurites=1,
+                                 params=params)
 
         rec = ds.create_recorders(gids, "length")
 
@@ -222,11 +223,11 @@ def test_persistence():
         fig.patch.set_alpha(0.)
         fig2.patch.set_alpha(0.)
 
-        # just check that no ridiculous number is encountered
-        for lp in persistences:
-            assert lp > 0. and np.abs((lp - l_p)/l_p) < 0.5
-
         plt.show()
+
+    # just check that no ridiculous number is encountered
+    for lp in persistences:
+        assert lp > 0. and np.abs((lp - l_p)/l_p) < 0.5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a modulation mechanism for speed to match previous models as reported in Aćimović *et al*. (2011), "Modeling of Neuronal Growth In Vitro : Comparison of Simulation Tools NETMORPH and CX3D".
The speed can now vary depending on the number *n* of growth cones as:

    v = v_0 * n^{-F}

Secondly, speed computation (which was incorrectly handled by ``GrowthCone``) is now properly handled by the ``elongator_`` object.