### PR TITLE
Add plot_dendrogram to neurite

### DIFF
--- a/src/pymodule/dense/elements.py
+++ b/src/pymodule/dense/elements.py
@@ -630,6 +630,48 @@ class Neurite(object):
         return _pg.set_neurite_properties(
             self._parent, self, params=params)
 
+    def plot_dendrogram(self, axis=None, show_node_id=False,
+                        aspect_ratio=None, vertical_diam_frac=0.2,
+                        ignore_diameter=False, show=True, **kwargs):
+        '''
+        Plot the dendrogram of a neurite.
+
+        Parameters
+        ----------
+        neurite : :class:`~dense.elements.Neurite` object
+            Neurite for which the dendrogram should be plotted.
+        axis : matplotlib.Axes.axis object, optional (default: new one)
+            Axis on which the dendrogram should be plotted.
+        show_node_id : bool, optional (default: False)
+            Display each node number on the branching points.
+        aspect_ratio : float, optional (default: variable)
+            Whether to use a fixed aspect ratio. Automatically set to 1 if
+            `show_node_id` is True.
+        vertical_diam_frac : float, optional (default: 0.2)
+            Fraction of the vertical spacing taken by the branch diameter.
+        ignore_diameter : bool, optional (default: False)
+            Plot all the branches with the same width.
+        show : bool, optional (default: True)
+            Whether the figure should be shown right away.
+        **kwargs : arguments for :class:`matplotlib.patches.Rectangle`
+            For instance `facecolor` or `edgecolor`.
+
+        Returns
+        -------
+        The axis on which the plot was done.
+
+        See also
+        --------
+        :func:`~dense.plot.plot_dendrogram`
+        '''
+        from .plot import plot_dendrogram
+
+        return plot_dendrogram(self, axis=axis, show_node_id=show_node_id,
+                               aspect_ratio=aspect_ratio,
+                               vertical_diam_frac=vertical_diam_frac,
+                               ignore_diameter=ignore_diameter, show=show,
+                               **kwargs)
+
     def _update_branches(self):
         cneurite          = _pg._to_bytes(str(self))
         self._branches    = []
@@ -797,17 +839,6 @@ class Tree(dict):
         neuron  = nmNeuron(soma, [neurite], [sections])
 
         return neuron
-
-    def show_dendrogram(self, **kwargs):
-        '''
-        Make and display the dendrogram.
-
-        See also
-        --------
-        Plotting arguments are the same as :func:`dense.plot.plot_dendrogram`.
-        '''
-        from .plot import plot_dendrogram
-        plot_dendrogram(self, **kwargs)
 
     def _cleanup(self):
         '''

--- a/src/pymodule/dense/plot/plot_structures.py
+++ b/src/pymodule/dense/plot/plot_structures.py
@@ -332,8 +332,8 @@ def plot_neurons(gid=None, mode="sticks", show_nodes=False, show_active_gc=True,
 # --------------- #
 
 def plot_dendrogram(neurite, axis=None, show_node_id=False,
-                     aspect_ratio=None, vertical_diam_frac=0.2,
-                     ignore_diameter=False, show=True, **kwargs):
+                    aspect_ratio=None, vertical_diam_frac=0.2,
+                    ignore_diameter=False, show=True, **kwargs):
     '''
     Plot the dendrogram of a neurite.
 
@@ -356,6 +356,14 @@ def plot_dendrogram(neurite, axis=None, show_node_id=False,
         Plot all the branches with the same width.
     **kwargs : arguments for :class:`matplotlib.patches.Rectangle`
         For instance `facecolor` or `edgecolor`.
+
+    Returns
+    -------
+    The axis on which the plot was done.
+
+    See also
+    --------
+    :func:`~dense.elements.Neurite.plot_dendrogram`
     '''
     import matplotlib.pyplot as plt
 
@@ -579,6 +587,8 @@ def plot_dendrogram(neurite, axis=None, show_node_id=False,
 
     if show:
         plt.show()
+
+    return axis
 
 
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# test_plots.py
+#
+# This file is part of DeNSE.
+#
+# Copyright (C) 2019 SeNEC Initiative
+#
+# DeNSE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# DeNSE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DeNSE. If not, see <http://www.gnu.org/licenses/>.
+
+
+""" Testing plot functions """
+
+import dense as ds
+from dense.units import *
+
+
+def test_dendrogram():
+    '''
+    Run each of the main functions.
+    '''
+    ds.reset_kernel()
+    ds.set_kernel_status('environment_required', False)
+
+    m  = ds.generate_model('constant', 'pull-only', 'noisy-weighted-average')
+
+    pp = {"growth_cone_model": m, "position": (0., 0.)*um}
+    np = {
+        "use_uniform_branching": True,
+        "uniform_branching_rate": 3.*cpd
+    }
+    gn = ds.create_neurons(params=pp, neurite_params=np, num_neurites=2)
+
+    ds.simulate(2*day)
+
+    ds.plot.plot_dendrogram(gn.axon, show=False)
+    gn.dendrites["dendrite_1"].plot_dendrogram(show=False)
+
+
+if __name__ == '__main__':
+    test_dendrogram()


### PR DESCRIPTION
Add an object-based option to plot the dendrogram of a ``Neurite``.
Remove plot_dendrogram from ``Tree``.
Add test in ``tests/test_plots.py``.