### PR TITLE
Correct create_neurites and add direct access to dendrites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ docs/modules/examples
 
 *.pdf
 *.swc
+*.nml
 *.json
 src/pymodule/dense/rw_in_env/ve
 src/pymodule/dense/ve

--- a/docs/user/neuronal_elements.rst
+++ b/docs/user/neuronal_elements.rst
@@ -135,6 +135,14 @@ be constrained in two different ways:
      with :math:`\chi` a uniform random variable on [0, 1].
 
 
+Examples:
+
+.. literalinclude:: ../../examples/tutorials/named_neurites.py
+    :linenos:
+    :language: python
+    :lines: 131-141
+
+
 .. note::
 
     Using ``num_neurites`` on growth cone creation with the
@@ -177,13 +185,19 @@ Properties of a neurite (axon or dendrites) are specific to this neurite, unlike
 those set using the neuronal parameters. They govern the growth process and the
 branching mechanisms of the neurite of interest.
 
-**Note : generic neurite properties both for dendrites' and axon's growth (see growth_model) can be assigned once as neuron parameters. These general settings can be overruled by the specific settings of dendrites' and axon's properties.**
+.. note ::
+
+    Generic neurite properties both for dendrites' and axon's growth (see
+    :ref:`pymodels`) can be assigned once as neuron parameters.
+    These general settings can be overruled by the specific settings of
+    dendrites' and axon's properties.
 
 Getting and setting properties
 ------------------------------
 
 All the properties described here can be set with
-:func:`~dense.set_object_properties` through the ``axon_params`` or ``dendrites_params`` dictionaries, or directly on the
+:func:`~dense.set_object_properties` through the ``axon_params`` or
+``dendrites_params`` dictionaries, or directly on the
 :class:`~dense.elements.Neurite` object through its
 :func:`~dense.elements.Neurite.set_properties`
 Some neurite-specific properties which are independent of the specific

--- a/docs/user/neuronal_elements.rst
+++ b/docs/user/neuronal_elements.rst
@@ -63,11 +63,14 @@ provide a value to the ``num_neurites`` argument (by default 0) in order to
 create the neurites directly.
 
 In |name|, the neurites are directly created with a specific type (either axon
-or dendrite); the types of the newly created neurites depend on the parameter
-``has_axon``, which determines whether the neuron has an `axon` or only
-dendrites. If ``has_axon`` is ``True``, then the first neurite created is an
-axon, while all subsequent neurites are dendrites. Otherwise, only dendrites
-are created. In that second case, if a network is created containing this
+or dendrite).
+The types of the newly created neurites depend on the parameter ``has_axon``,
+which determines whether the neuron has an `axon` or only dendrites and on the
+name of the neurite.
+If ``has_axon`` is ``True``, then naming a neurite "axon" is authorized and
+will create an axon, while any other name will be associated to a dendrite.
+If ``has_axon`` is ``False``, only dendrites are created.
+In that second case, if a network is created containing this
 neuron, the corresponding node in the generated network will only have
 incoming edges.
 
@@ -76,9 +79,10 @@ automatically as ``("axon", "dendrite_1", "dendrite_2", ...)`` or be user
 defined (except for the axon, which must always be named ``"axon"``).
 Custom names for neurites can be provided through the following methods:
 
-1. via the `neurite_names` entry (especially useful if no specific
-   parameters are provided),
-2. directly as entries in the `neurite_params` dictionary containing the
+1. via the `neurite_names` entry for :func:`~dense.create_neurites` (especially
+   useful if no specific parameters are provided), or directly as `names`
+   when using the :meth:`~dense.elements.Neuron.create_neurites` method.
+2. directly as keys in the `neurite_params`/`params` dictionary containing the
    specific parameters for each neurite.
 
 These two methods are shown below:
@@ -92,19 +96,20 @@ For more details, see the `example file <https://github.com/SENeC-Initiative/DeN
 
 Optionally, neurites can also be created after the neuron's creation, using the
 :func:`~dense.create_neurites` function or calling the
-:func:`~dense.elements.Neuron.create_neurites` method of the
+:meth:`~dense.elements.Neuron.create_neurites` method of the
 :class:`~dense.elements.Neuron`.
 
 The neurites created that way will emerge from the neuron with angles that can
 be constrained in two different ways:
 
-1. Using ``neurite_angles`` to explicitly set the angles of the dendrites and
-   axon relative to the horizontal. E.g.
-   ``{neurite_angles": {"axon": 15, "dendrite_1": 60, "dendrite_2": 180}``.
+1. Using ``neurite_angles`` in the neuron parameter dictionary to explicitly
+   set the angles of the dendrites and axon relative to the horizontal. E.g.
+   ``{"neurite_angles": {"axon": 15, "dendrite_1": 60, "dendrite_2": 180}``.
    This parameter can only be used upon neuron creation through the
    :func:`~dense.create_neurons` function.
    Otherwise, the neurite angle can also be set directly using the
-   :func:`~dense.create_neurites` function after neuron creation.
+   :func:`~dense.create_neurites` function after neuron creation or via
+   ``angles`` in :meth:`~dense.elements.Neuron.create_neurites`.
    This parameter can be combined with `random_rotation_angles``.
    When set to `True`, this wil randomly rotate the neurites as a block,
    preserving their relative angles.

--- a/examples/tutorials/1_first-steps.py
+++ b/examples/tutorials/1_first-steps.py
@@ -37,7 +37,7 @@ from dense.units import *
 n = ds.create_neurons()
 
 # adding neurites
-n.create_neurites(2)
+n.create_neurites(2, names=["axon", "dendrite_1"])
 
 
 ''' Access the neurites and set the parameters '''

--- a/examples/tutorials/named_neurites.py
+++ b/examples/tutorials/named_neurites.py
@@ -115,3 +115,36 @@ except Exception as e:
     error_caught = True
 
 assert error_caught, "Previous code should have failed (incompatible names)."
+
+
+''' Compare methods '''
+
+
+angles = {"axon": 90.*deg, "dendrite": 210.*deg}
+
+params = {
+    "position": (0., 0.)*um,
+    "neurite_angles": angles,
+    "random_rotation_angles": False
+}
+
+# at neuron creation
+neuron = ds.create_neurons(params=params, num_neurites=2,
+                           neurite_names=["axon", "dendrite"])
+
+# after neuron creation
+neurons = ds.create_neurons(2)
+
+neurons[5].create_neurites(2, names=["axon", "dendrite"], angles=angles)
+
+ds.create_neurites(neurons[6], num_neurites=2, names=["axon", "dendrite"],
+                   angles=angles)
+
+import numpy as np
+
+for k, v in angles.items():
+    assert np.isclose(neuron.neurite_angles[k], v)
+
+for n in neurons:
+    for k, v in angles.items():
+        assert np.isclose(n.neurite_angles[k], v)

--- a/src/elements/Neuron.cpp
+++ b/src/elements/Neuron.cpp
@@ -314,6 +314,15 @@ void Neuron::init_status(
 }
 
 
+void Neuron::update_angles(const std::unordered_map<std::string, double> &angles)
+{
+    for (auto entry : angles)
+    {
+        neurite_angles_[entry.first] = rnd_angle_ + entry.second;
+    }
+}
+
+
 void Neuron::initialize_next_event(mtPtr rnd_engine)
 {
     if (use_actin_waves_ and next_actin_event_ == 0)

--- a/src/elements/Neuron.hpp
+++ b/src/elements/Neuron.hpp
@@ -129,6 +129,7 @@ class Neuron : public std::enable_shared_from_this<Neuron>
     void get_neurite_status(statusMap &status, std::string neurite_type,
                             const std::string &level);
     void update_kernel_variables();
+    void update_angles(const std::unordered_map<std::string, double> &angles);
 
     bool has_axon() const;
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -106,7 +106,8 @@ stype create_neurons_(
 void create_neurites_(
     const std::vector<stype> &neurons, stype num_neurites,
     const std::unordered_map<std::string, std::vector<statusMap>> &params,
-    const std::vector<std::string> &names, const std::vector<double> &angles)
+    const std::vector<std::string> &names,
+    const std::unordered_map<std::string, double> &angles)
 {
     int num_omp = kernel().parallelism_manager.get_num_local_threads();
     std::vector<std::vector<stype>> omp_neuron_vec(num_omp);
@@ -156,6 +157,9 @@ void create_neurites_(
             {
                 NeuronPtr neuron =
                     kernel().neuron_manager.get_neuron(neurons[i]);
+
+                // update angles
+                neuron->update_angles(angles);
 
                 statusMap status = vec_statuses[i];
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -103,12 +103,10 @@ stype create_neurons_(
 }
 
 
-void create_neurites_(const std::vector<stype> &neurons,
-                      stype num_neurites,
-                      const std::vector<statusMap> &params,
-                      const std::vector<std::string> &neurite_types,
-                      const std::vector<double> &angles,
-                      const std::vector<std::string> &names)
+void create_neurites_(
+    const std::vector<stype> &neurons, stype num_neurites,
+    const std::unordered_map<std::string, std::vector<statusMap>> &params,
+    const std::vector<std::string> &names, const std::vector<double> &angles)
 {
     int num_omp = kernel().parallelism_manager.get_num_local_threads();
     std::vector<std::vector<stype>> omp_neuron_vec(num_omp);
@@ -127,70 +125,61 @@ void create_neurites_(const std::vector<stype> &neurons,
         bool gc_model_set;
         GCPtr gc_ptr;
 
-        for (stype i : omp_neuron_vec[omp_id])
+        // loop neurites/params
+        for (const std::string &name : names)
         {
-            NeuronPtr neuron = kernel().neuron_manager.get_neuron(neurons[i]);
-            statusMap status = params[i];
+            auto it = params.find(name);
 
-            stype existing_neurites = neuron->get_num_neurites();
-            bool has_axon           = neuron->has_axon();
+            std::vector<statusMap> vec_statuses;
 
-            gc_model_set = get_param(status, "growth_cone_model", gc_model);
-
-            if (not gc_model_set)
+            if (it == params.end())
             {
-                gc_model = neuron->get_gc_model();
-            }
+                it = params.find("dendrites");
 
-            gc_ptr = kernel().model_manager.get_model(gc_model);
-
-            if (neurite_types.empty())
-            {
-                for (stype j = 0; j < num_neurites; j++)
+                if (it == params.end())
                 {
-                    if ((names.empty() and has_axon and
-                         existing_neurites + j == 0) or
-                        (not names.empty() and names[j] == "axon"))
-                    {
-                        neuron->new_neurite("axon", "axon", gc_ptr, rng);
-                        neuron->set_neurite_status("axon", status);
-                    }
-                    else
-                    {
-                        std::string name =
-                            names.empty()
-                                ? "dendrite_" +
-                                      std::to_string(existing_neurites + j)
-                                : names[j];
-                        neuron->new_neurite(name, "dendrite", gc_ptr, rng);
-                        neuron->set_neurite_status(name, status);
-                    }
+                    vec_statuses =
+                        std::vector<statusMap>(omp_neuron_vec[omp_id].size());
+                }
+                else
+                {
+                    vec_statuses = it->second;
                 }
             }
             else
             {
-                for (stype j = 0; j < num_neurites; j++)
-                {
-                    if (neurite_types[j] == "axon")
-                    {
-                        if (not names.empty() and names[j] != "axon")
-                        {
-                            exit(INVALID_AXON_NAME);
-                        }
+                vec_statuses = it->second;
+            }
 
-                        neuron->new_neurite("axon", "axon", gc_ptr, rng);
-                        neuron->set_neurite_status("axon", status);
-                    }
-                    else
-                    {
-                        std::string name =
-                            names.empty()
-                                ? "dendrite_" +
-                                      std::to_string(existing_neurites + j)
-                                : names[j];
-                        neuron->new_neurite(name, "dendrite", gc_ptr, rng);
-                        neuron->set_neurite_status(name, status);
-                    }
+            // loop neurons
+            for (stype i : omp_neuron_vec[omp_id])
+            {
+                NeuronPtr neuron =
+                    kernel().neuron_manager.get_neuron(neurons[i]);
+
+                statusMap status = vec_statuses[i];
+
+                stype existing_neurites = neuron->get_num_neurites();
+                bool has_axon           = neuron->has_axon();
+
+                gc_model_set = get_param(status, "growth_cone_model", gc_model);
+
+                if (not gc_model_set)
+                {
+                    gc_model = neuron->get_gc_model();
+                }
+
+                gc_ptr = kernel().model_manager.get_model(gc_model);
+
+                if (name == "axon")
+                {
+                    neuron->new_neurite("axon", "axon", gc_ptr, rng);
+                    neuron->set_neurite_status("axon", status);
+                }
+                else
+                {
+                    neuron->new_neurite(name, "dendrite", gc_ptr, rng);
+                    neuron->set_neurite_status(name, status);
                 }
             }
         }

--- a/src/module.hpp
+++ b/src/module.hpp
@@ -69,11 +69,10 @@ stype create_neurons_(
     const std::unordered_map<std::string, std::vector<statusMap>> &neurite_params);
 
 
-void create_neurites_(const std::vector<stype> &neurons, stype num_neurites,
-                      const std::vector<statusMap> &params,
-                      const std::vector<std::string> &neurite_types,
-                      const std::vector<double> &angles,
-                      const std::vector<std::string> &names);
+void create_neurites_(
+    const std::vector<stype> &neurons, stype num_neurites,
+    const std::unordered_map<std::string, std::vector<statusMap>> &params,
+    const std::vector<std::string> &names, const std::vector<double> &angles);
 
 
 void delete_neurons_(const std::vector<stype> &gids);

--- a/src/module.hpp
+++ b/src/module.hpp
@@ -72,7 +72,8 @@ stype create_neurons_(
 void create_neurites_(
     const std::vector<stype> &neurons, stype num_neurites,
     const std::unordered_map<std::string, std::vector<statusMap>> &params,
-    const std::vector<std::string> &names, const std::vector<double> &angles);
+    const std::vector<std::string> &names,
+    const std::unordered_map<std::string, double> &angles);
 
 
 void delete_neurons_(const std::vector<stype> &gids);

--- a/src/pymodule/dense/_pygrowth.pxd.in
+++ b/src/pymodule/dense/_pygrowth.pxd.in
@@ -107,7 +107,8 @@ cdef extern from "../module.hpp" namespace "growth":
     cdef void create_neurites_(
         const vector[stype]& neurons, stype num_neurites,
         const unordered_map[string, vector[statusMap]]& params,
-        const vector[string]& names, const vector[double]& angles) except +
+        const vector[string]& names,
+        const unordered_map[string, double]& angles) except +
 
     cdef void delete_neurons_(const vector[stype] &neurons) except +
 

--- a/src/pymodule/dense/_pygrowth.pxd.in
+++ b/src/pymodule/dense/_pygrowth.pxd.in
@@ -104,12 +104,10 @@ cdef extern from "../module.hpp" namespace "growth":
         const vector[statusMap]& neuron_params,
         const unordered_map[string, vector[statusMap]]& neurite_params) except +
 
-    cdef void create_neurites_(const vector[stype]& neurons,
-                               stype num_neurites,
-                               const vector[statusMap]& params,
-                               const vector[string]& neurite_types,
-                               const vector[double]& angles,
-                               const vector[string]& names) except +
+    cdef void create_neurites_(
+        const vector[stype]& neurons, stype num_neurites,
+        const unordered_map[string, vector[statusMap]]& params,
+        const vector[string]& names, const vector[double]& angles) except +
 
     cdef void delete_neurons_(const vector[stype] &neurons) except +
 
@@ -206,6 +204,8 @@ cdef extern from "../module.hpp" namespace "growth":
                              const string& time_units) except +
 
     cdef string object_type_(stype gid) except +
+
+    cdef bool neuron_has_axon_(stype gid) except +
 
     cdef void reset_kernel_() except +
 

--- a/src/pymodule/dense/_pygrowth.pyx
+++ b/src/pymodule/dense/_pygrowth.pyx
@@ -333,6 +333,9 @@ def create_neurites(neurons, num_neurites=1, params=None, angles=None,
     '''
     Create neurites on the specified neurons.
 
+    Neurite types (axon or dendrite) are based on the neurite names: axon must
+    always be named "axon", all other names will be associated to a dendrite.
+
     Parameters
     ----------
     neurons : :class:`~dense.elements.Neuron`, list, or GIDs
@@ -355,11 +358,6 @@ def create_neurites(neurons, num_neurites=1, params=None, angles=None,
     be created for each neuron; to create varying numbers, types, or
     relative angles for the neurites, the function must be called
     separately on the different sets of neurons.
-
-    .. warning ::
-
-        Axon name must always be "axon", trying to name it differently
-        will lead to an immediate crash.
     '''
     cdef:
         vector[stype] cneurons
@@ -391,10 +389,10 @@ def create_neurites(neurons, num_neurites=1, params=None, angles=None,
 
         names = set(names)
 
+        assert len(names) == len(old_names), "`names` are not unique."
+
         assert len(names) == num_neurites, \
             "`names` must contain exactly `num_neurites` entries."
-
-        assert len(names) == len(old_names), "`names` are not unique."
 
         # check that names and params entries fit
         if params and isinstance(next(iter(params.values())), dict):

--- a/src/pymodule/dense/_pygrowth.pyx
+++ b/src/pymodule/dense/_pygrowth.pyx
@@ -198,7 +198,7 @@ def create_neurons(n=1, params=None, num_neurites=0, neurite_params=None,
 
     params       = {} if params is None else params.copy()
     neur_params  = {} if neurite_params is None \
-                   else neurite_params.copy()
+                   else deepcopy(neurite_params)
     env_required = get_kernel_status("environment_required")
 
     # num_neurites and neurite names go in kwargs for params check and
@@ -287,18 +287,11 @@ def create_neurons(n=1, params=None, num_neurites=0, neurite_params=None,
                              "`neurite_angles`, choose one or the other.")
 
     # check parameters
-    _check_params(params, "neuron",
-                  gc_model=params["growth_cone_model"])
+    gc_model = params["growth_cone_model"]
 
-    if neur_params:
-        if isinstance(next(iter(neur_params.values())), dict):
-            for key, val in neur_params.items():
-                _check_params(val, "neurite",
-                              gc_model=val.get("growth_cone_model",
-                                               gc_model))
-    else:
-        gcm = neur_params.get("growth_cone_model", gc_model)
-        _check_params(neur_params, "neurite", gc_model=gcm)
+    _check_params(params, "neuron", gc_model=gc_model)
+
+    _check_neurite_params(neur_params, gc_model)
 
     params = neuron_param_parser(
         params, culture, n, rnd_pos=rnd_pos, on_area=on_area)
@@ -334,8 +327,9 @@ def create_neurons(n=1, params=None, num_neurites=0, neurite_params=None,
     return _create_neurons(
         params, neur_params, kwargs, n, return_ints)
 
+
 def create_neurites(neurons, num_neurites=1, params=None, angles=None,
-                    neurite_types=None, names=None):
+                    names=None):
     '''
     Create neurites on the specified neurons.
 
@@ -349,13 +343,11 @@ def create_neurites(neurons, num_neurites=1, params=None, angles=None,
         Parameters of the neurites.
     angle : list, optional (default: automatically positioned)
         Angles of the newly created neurites.
-    neurite_types : str or list, optional
-        Types of the neurites, either "axon" or "dendrite". If not
-        provided, the first neurite will be an axon if the neuron has
-        no existing neurites and its `has_axon` variable is True,
-        all other neurites will be dendrites.
     names : list, optional (default: "axon" and "dendrite_X")
-        Names of the created neurites.
+        Names of the created neurites, if not provided, will an "axon" or
+        a dendrite with default name "dendrite_X" (X being a number) will be
+        created, depending on whether the neuron is supposed to have an axon
+        or not, and depending on the number of pre-existing neurites.
 
     Note
     ----
@@ -367,37 +359,28 @@ def create_neurites(neurons, num_neurites=1, params=None, angles=None,
     .. warning ::
 
         Axon name must always be "axon", trying to name it differently
-        will immediately crash the kernel.
+        will lead to an immediate crash.
     '''
     cdef:
         vector[stype] cneurons
         vector[double] cangles
-        vector[string] cneurite_types, cneurite_names
+        vector[string] cneurite_names
         statusMap common_params
-        vector[statusMap] cparams
+        vector[statusMap] vparams
+        unordered_map[string, vector[statusMap]] cparams
 
-    params = {} if params is None else params.copy()
+    params = {} if params is None else deepcopy(params)
 
     if not nonstring_container(neurons):
         neurons = [neurons]
     for n in neurons:
         cneurons.push_back(int(n))
 
+    num_neurons = len(neurons)
+
     if angles is not None:
         for theta in angles:
             cangles.push_back(theta)
-
-    if neurite_types is not None:
-        if not nonstring_container(neurite_types):
-            neurite_types = [neurite_types]
-
-        assert len(neurite_types) == num_neurites, \
-            "`neurite_types` must contain exactly `num_neurites` entries."
-
-        for s in neurite_types:
-            assert s in ("axon", "dendrite"), \
-                "Only 'axon' and 'dendrite' are allowed in `neurite_types`."
-            cneurite_types.push_back(_to_bytes(s))
 
     if names is not None:
         if not nonstring_container(names):
@@ -408,33 +391,57 @@ def create_neurites(neurons, num_neurites=1, params=None, angles=None,
 
         assert len(names) == len(set(names)), "`names` are not unique."
 
+        # check that names and params entries fit
+        if params and isinstance(next(iter(params.values())), dict):
+            # check whether generic "dendrites" entry was used
+            if "dendrites" not in params:
+                assert set(names).contains(params.keys()), \
+                "Some entries in `params` have no associated name in `names`."
+
         for s in names:
             if s == "axon":
                 for n in cneurons:
                     has_axon = neuron_has_axon_(n)
                     neurites = get_neurites_(n)
+
+                    error = "To create a neurite called 'axon', the neurons " +\
+                            "have their `has_axon` parameter to True, and " +\
+                            "should not already possess an axon. "
+    
                     assert has_axon, \
-                        "To create a neurite called 'axon', the neurons " +\
-                        "have their `has_axon` parameter to True, and " +\
-                        "should not already possess an axon. Neuron " +\
-                        "{} has `has_axon` to False.".format(n)
+                        error + "Neuron {} has `has_axon` to False.".format(n)
+
                     assert b"axon" not in list(neurites), \
-                        "To create a neurite called 'axon', the neurons " +\
-                        "have their `has_axon` parameter to True, and " +\
-                        "should not already possess an axon. Neuron " +\
-                        "{} already has an axon.".format(n)
+                        error + "Neuron {} already has an axon.".format(n)
 
             cneurite_names.push_back(_to_bytes(s))
+    else:
+        has_axon = neuron_has_axon_(cneurons[0])
+        names    = _set_neurite_names(has_axon, num_neurites, params)
 
-    _check_params(params, "neurite")
+        cneurite_names = [_to_bytes(name) for name in names]
 
-    common_params = _get_scalar_status(params, num_neurites)
-    cparams       = vector[statusMap](num_neurites, common_params)
+    _check_neurite_params(params, "simple-random-walk")
 
-    _set_vector_status(cparams, params)
+    # create c-parameters
+    if params and isinstance(next(iter(params.values())), dict):
+        for key, val in params.items():
+            common_params = _get_scalar_status(val, num_neurons)
 
-    create_neurites_(cneurons, num_neurites, cparams, cneurite_types,
-                     cangles, cneurite_names)
+            vparams = vector[statusMap](num_neurons, common_params)
+            _set_vector_status(vparams, val)
+
+            cparams[_to_bytes(key)] = vparams
+    else:
+        common_params = _get_scalar_status(params, num_neurons)
+
+        vparams = vector[statusMap](num_neurons, common_params)
+        _set_vector_status(vparams, params)
+
+        for neurite in names:
+            cparams[_to_bytes(neurite)] = vparams
+
+    create_neurites_(cneurons, num_neurites, cparams, cneurite_names, cangles)
 
 
 def create_recorders(targets, observables, sampling_intervals=None,
@@ -1737,13 +1744,14 @@ cdef _create_neurons(dict params, dict neurite_params,
     base_neuron_status = _get_scalar_status(params, n)
 
     # check if neurite_params is a single dict or a dict of dicts
+    # NOTE: using `create_neurons`, entry "dendrites" in neurite_params is
+    # handled at the C++ level
     dod = (neurite_params
            and isinstance(next(iter(neurite_params.values())), dict))
 
     if not dod:
         neurite_params = {k: neurite_params for k in neurite_names}
 
-    # same for neurite parameters
     for key, value in neurite_params.items():
         base_neurite_statuses[_to_bytes(key)] = \
             _get_scalar_status(value, n)
@@ -2121,7 +2129,7 @@ cdef Property _to_property(key, value) except *:
             for val in value:
                 c_lvec.push_back(val)
             cprop = Property(c_lvec, c_dim)
-    elif is_iterable(value) and isinstance(next(iter(value)), str):
+    elif is_iterable(value) and value and isinstance(next(iter(value)), str):
         for val in value:
             c_svec.push_back(_to_bytes(val))
         cprop = Property(c_svec, c_dim)
@@ -2759,6 +2767,20 @@ def _check_params(params, object_name, gc_model=None):
             if key not in ("position",):
                 raise KeyError(
                     "Unknown parameter '{}' for `{}`.".format(key, object_name))
+
+
+def _check_neurite_params(params, gc_model):
+    '''
+    Check that parameters are valid for neurites
+    '''
+    if params:
+        if isinstance(next(iter(params.values())), dict):
+            for p in params.values():
+                gcm = p.get("growth_cone_model", gc_model)
+                _check_params(p, "neurite", gc_model=gcm)
+        else:
+            gcm = params.get("growth_cone_model", gc_model)
+            _check_params(params, "neurite", gc_model=gcm)
 
 
 def _set_neurite_names(has_axon, num_neurites, neurite_params):

--- a/src/pymodule/dense/_pygrowth.pyx
+++ b/src/pymodule/dense/_pygrowth.pyx
@@ -361,7 +361,7 @@ def create_neurites(neurons, num_neurites=1, params=None, angles=None,
     '''
     cdef:
         vector[stype] cneurons
-        vector[double] cangles
+        unordered_map[string, double] cangles
         vector[string] cneurite_names
         statusMap common_params
         vector[statusMap] vparams
@@ -378,8 +378,8 @@ def create_neurites(neurons, num_neurites=1, params=None, angles=None,
     num_neurons = len(neurons)
 
     if angles is not None:
-        for theta in angles:
-            cangles.push_back(theta)
+        for neurite, theta in angles.items():
+            cangles[_to_bytes(neurite)] = theta
 
     if names is not None:
         if not nonstring_container(names):

--- a/src/pymodule/dense/elements.py
+++ b/src/pymodule/dense/elements.py
@@ -153,6 +153,10 @@ class Neuron(object):
         '''
         Create new neurites.
 
+        Neurite types (axon or dendrite) are based on the neurite names: axon
+        must always be named "axon", all other names will be associated to a
+        dendrite.
+
         Parameters
         ----------
         num_neurites : int, optional (default: 1)

--- a/src/pymodule/dense/elements.py
+++ b/src/pymodule/dense/elements.py
@@ -171,8 +171,8 @@ class Neuron(object):
         --------
         :func:`~dense.create_neurites`.
         '''
-        _pg.create_neurites(self, num_neurites=num_neurites,
-                            params=params, angles=angles, names=names)
+        _pg.create_neurites(self, num_neurites=num_neurites, params=params,
+                            angles=angles, names=names)
 
     def delete_neurites(self, neurite_names=None):
         '''

--- a/src/pymodule/dense/elements.py
+++ b/src/pymodule/dense/elements.py
@@ -81,6 +81,9 @@ class Neuron(object):
 
     def __getattr__(self, attribute):
         ''' Access neuronal properties directly '''
+        if attribute in self.dendrites:
+            return self.dendrites[attribute]
+
         ndict = _pg.get_object_properties(self, level="neuron")
 
         if attribute in ndict:
@@ -118,11 +121,13 @@ class Neuron(object):
         Return a dict containing one :class:`~dense.elements.Neurite` container
         for each dendrite, with its name as key.
         '''
-        neurites = [k for k in _pg._get_neurites(self) if k != "axon"]
+        neurites  = [k for k in _pg._get_neurites(self) if k != "axon"]
         dendrites = {}
+
         for name in neurites:
             dendrites[name] = Neurite(
                 None, "dendrite", name=name, parent=self)
+
         return dendrites
 
     @property
@@ -132,8 +137,10 @@ class Neuron(object):
         for each neurite, with its name as key.
         '''
         neurites = self.dendrites
+
         if self.axon is not None:
             neurites[self.axon.name] = self.axon
+
         return neurites
 
     @property
@@ -142,7 +149,7 @@ class Neuron(object):
         return _pg.get_object_state(self, observable="length")
 
     def create_neurites(self, num_neurites=1, params=None, angles=None,
-                        neurite_types=None, names=None):
+                        names=None):
         '''
         Create new neurites.
 
@@ -154,21 +161,18 @@ class Neuron(object):
             Parameters of the neurites.
         angle : list, optional (default: automatically positioned)
             Angles of the newly created neurites.
-        neurite_types : str or list, optional
-            Types of the neurites, either "axon" or "dendrite". If not provided,
-            the first neurite will be an axon if the neuron has no existing
-            neurites and its `has_axon` variable is True, all other neurites
-            will be dendrites.
         names : str or list, optional (default: "axon" and "dendrite_X")
-            Names of the created neurites.
+            Names of the created neurites, if not provided, will an "axon" or
+            a dendrite with default name "dendrite_X" (X being a number) will be
+            created, depending on whether the neuron is supposed to have an axon
+            or not, and depending on the number of pre-existing neurites.
 
         See also
         --------
         :func:`~dense.create_neurites`.
         '''
         _pg.create_neurites(self, num_neurites=num_neurites,
-                            params=params, angles=angles,
-                            neurite_types=neurite_types, names=names)
+                            params=params, angles=angles, names=names)
 
     def delete_neurites(self, neurite_names=None):
         '''

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -68,22 +68,6 @@ def test_create_neurites_one_neuron():
     assert neuron.dendrite1.speed_growth_cone == 0.02*um/minute
     assert neuron.dendrite2.speed_growth_cone == 0.03*um/minute
 
-    # with one neuron, create neurites using "dendrites"
-    neuron = ds.create_neurons()
-
-    neurite_params = {
-        "axon": {"speed_growth_cone": 0.1*um/minute},
-        "dendrites": {"speed_growth_cone": 0.0254*um/minute}
-    }
-
-    neuron.create_neurites(num_neurites=3, params=neurite_params)
-
-    assert set(neuron.neurites.keys()) == {"axon", "dendrite_1", "dendrite_2"}
-    assert neuron.axon.speed_growth_cone == 0.1*um/minute
-
-    for dendrite in neuron.dendrites.values():
-        assert dendrite.speed_growth_cone == 0.0254*um/minute
-
     # with one neuron, create neurites using "dendrites" and names
     neuron = ds.create_neurons()
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -45,5 +45,106 @@ def test_create():
     assert not neuron.neurites
 
 
+def test_create_neurites_one_neuron():
+    '''
+    Detailed neurite creation for a single neuron
+    '''
+    ds.reset_kernel()
+
+    # with one neuron, create neurites, all named
+    neuron = ds.create_neurons()
+
+    neurite_params = {
+        "axon": {"speed_growth_cone": 0.1*um/minute},
+        "dendrite1": {"speed_growth_cone": 0.02*um/minute},
+        "dendrite2": {"speed_growth_cone": 0.03*um/minute}
+    }
+
+    neuron.create_neurites(num_neurites=3, params=neurite_params)
+
+    assert len(neuron.neurites) == 3
+    assert set(neuron.dendrites.keys()) == {"dendrite1", "dendrite2"}
+    assert neuron.axon.speed_growth_cone == 0.1*um/minute
+    assert neuron.dendrite1.speed_growth_cone == 0.02*um/minute
+    assert neuron.dendrite2.speed_growth_cone == 0.03*um/minute
+
+    # with one neuron, create neurites using "dendrites"
+    neuron = ds.create_neurons()
+
+    neurite_params = {
+        "axon": {"speed_growth_cone": 0.1*um/minute},
+        "dendrites": {"speed_growth_cone": 0.0254*um/minute}
+    }
+
+    neuron.create_neurites(num_neurites=3, params=neurite_params)
+
+    assert set(neuron.neurites.keys()) == {"axon", "dendrite_1", "dendrite_2"}
+    assert neuron.axon.speed_growth_cone == 0.1*um/minute
+
+    for dendrite in neuron.dendrites.values():
+        assert dendrite.speed_growth_cone == 0.0254*um/minute
+
+    # with one neuron, create neurites using "dendrites" and names
+    neuron = ds.create_neurons()
+
+    neurite_params = {
+        "axon": {"speed_growth_cone": 0.1*um/minute},
+        "dendrites": {"speed_growth_cone": 0.0256*um/minute}
+    }
+
+    neuron.create_neurites(num_neurites=3, params=neurite_params,
+                           names=["axon", "d1", "d2"])
+
+    assert set(neuron.neurites.keys()) == {"axon", "d1", "d2"}
+    assert neuron.axon.speed_growth_cone == 0.1*um/minute
+
+    for dendrite in neuron.dendrites.values():
+        assert dendrite.speed_growth_cone == 0.0256*um/minute
+
+    # with one neuron, create neurites with all same parameters and names
+    neuron = ds.create_neurons()
+
+    neurite_params = {"speed_growth_cone": 0.0236*um/minute}
+
+    neuron.create_neurites(num_neurites=3, params=neurite_params,
+                           names=["axon", "dend1", "dend2"])
+
+    assert set(neuron.neurites.keys()) == {"axon", "dend1", "dend2"}
+    for neurite in neuron.neurites.values():
+        assert neurite.speed_growth_cone == 0.0236*um/minute
+
+
+def test_create_neurites_many_neurons():
+    '''
+    Detailed neurite creation for many neurons
+    '''
+    ds.reset_kernel()
+
+    # with two neurons, create neurites, all named
+    neurons = ds.create_neurons(2)
+
+    neurite_params = {
+        "axon": {"speed_growth_cone": [0.1, 0.095]*um/minute},
+        "d1": {"speed_growth_cone": [0.02, 0.021]*um/minute},
+        "d2": {"speed_growth_cone": [0.03, 0.029]*um/minute}
+    }
+
+    ds.create_neurites(neurons, num_neurites=3, params=neurite_params)
+
+    for neuron in neurons:
+        assert set(neuron.neurites.keys()) == {"axon", "d1", "d2"}
+
+    assert neurons[0].axon.speed_growth_cone == 0.1*um/minute
+    assert neurons[1].axon.speed_growth_cone == 0.095*um/minute
+
+    assert neurons[0].d1.speed_growth_cone == 0.02*um/minute
+    assert neurons[1].d1.speed_growth_cone == 0.021*um/minute
+
+    assert neurons[0].d2.speed_growth_cone == 0.03*um/minute
+    assert neurons[1].d2.speed_growth_cone == 0.029*um/minute
+
+
 if __name__ == "__main__":
     test_create()
+    test_create_neurites_one_neuron()
+    test_create_neurites_many_neurons()

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -127,7 +127,7 @@ def test_delete_neurites():
         assert len(n.neurites) == 1, \
             "Failed with state " + str(initial_state)
 
-    ds.create_neurites(neurons[0], neurite_types="axon")
+    ds.create_neurites(neurons[0], names="axon")
 
     assert neurons[0].has_axon, \
         "Failed with state " + str(initial_state)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -71,8 +71,21 @@ def test_elements():
     for obs in neuron.get_properties("observables"):
         neuron.get_state(obs)
 
-    neuron.create_neurites()
+    # cannot create existing neurite
+    failed = False
+
+    try:
+        neuron.create_neurites(names="dendrite_1")
+    except:
+        failed = True
+
+    assert failed
+
+    neuron.create_neurites(names="dendrite_2")
+
     neuron.delete_neurites("dendrite_1")
+
+    neuron.create_neurites(names="dendrite_1")
 
     # test neurite
     neuron.axon.get_properties()


### PR DESCRIPTION
This PR updates the ``ds.create_neurites`` and ``Neurite.create_neurites`` functions to handle named neurites.
It also makes dendrites directly accessible from the ``Neuron`` using their names (e.g. ``neuron.dendr1``).

Addresses #24 