### PR TITLE
Move to initial_diameter for neurites

### DIFF
--- a/docs/user/neuronal_elements.rst
+++ b/docs/user/neuronal_elements.rst
@@ -166,8 +166,7 @@ and set its properties directly through the methods of the
 Besides the parameters discussed previously, one can also set the following
 properties of the neuron:
 
-* ``axon_diameter`` and ``dendrite_diameter`` specify the initial diameter
-  (at the soma) of both types  of neurites,
+* ``soma_radius`` to characterize the size of the cell body,
 
 * ``description`` contains a string which can by used to differenciate this
   neuron from other elements,
@@ -188,7 +187,7 @@ branching mechanisms of the neurite of interest.
 .. note ::
 
     Generic neurite properties both for dendrites' and axon's growth (see
-    :ref:`pymodels`) can be assigned once as neuron parameters.
+    :ref:`pymodels`) can also be assigned for all neurites as neuron parameters.
     These general settings can be overruled by the specific settings of
     dendrites' and axon's properties.
 
@@ -214,6 +213,8 @@ Some neurite-specific properties which are independent of the specific
   reduction of the neurite diameter with distance from the soma. At a distance
   :math:`l` from the soma, the diameter an unbranched neurite will thus be
   :math:`d = d_0 - r_t\cdot l`.
+
+* ``initial_diameter`` gives the size of the neurite at the soma.
 
 From a :class:`~dense.elements.Neuron` object, the neurites can directly be
 accessed using the ``axon`` or ``dendrites`` properties: ::

--- a/docs/user/tutorial.rst
+++ b/docs/user/tutorial.rst
@@ -73,7 +73,7 @@ Once this is done, we can set the various parameters for the simulation and the 
 .. literalinclude:: ../../examples/tutorials/2_interacting-neurons.py
     :linenos:
     :language: python
-    :lines: 35-55
+    :lines: 35-58
 
 The first line here declares the number of OpenMP processes that will be used, i.e. how many parallel threads will be used to perform the simulation.
 The second line will be used to set the number of neurons that will be simulated.
@@ -93,7 +93,7 @@ Once all these parameters are declared, we can configure DeNSE and create the ne
 .. literalinclude:: ../../examples/tutorials/2_interacting-neurons.py
     :linenos:
     :language: python
-    :lines: 59-64
+    :lines: 60-65
 
 As can be seen above, one uses the ``ds`` variable to access the simulator main function. 
 The :func:`~dense.set_kernel_status` function is used here to transfer the parameters to the kernel of DeNSE (the main simulator units).
@@ -109,7 +109,7 @@ Following neuron creation, the simulation can be started and its result can be v
 .. literalinclude:: ../../examples/tutorials/2_interacting-neurons.py
     :linenos:
     :language: python
-    :lines: 67-75
+    :lines: 68-76
 
 After this first 7 day simulation, the parameters of the neurons can be changed to account for changes in developmental mechanisms, so that these new
 parameters can be used to simulate the next part of these cells' growth.
@@ -117,7 +117,7 @@ parameters can be used to simulate the next part of these cells' growth.
 .. literalinclude:: ../../examples/tutorials/2_interacting-neurons.py
     :linenos:
     :language: python
-    :lines: 78-97
+    :lines: 79-98
 
 Here we changed separately the dendritic and axonal parameters using the :func:`~dense.set_object_properties` function on the two neurons which are
 stored in the ``n`` variable (the neurons stored in a :class:`~dense.elements.Population` object).
@@ -128,7 +128,7 @@ Note that the ``neuroml`` python module is necessary to use :func:`~dense.io.sav
 .. literalinclude:: ../../examples/tutorials/2_interacting-neurons.py
     :linenos:
     :language: python
-    :lines: 102-103
+    :lines: 103-104
 
 
 Multiprocessing and random number generation

--- a/examples/2chambers/2chambers.py
+++ b/examples/2chambers/2chambers.py
@@ -66,8 +66,6 @@ use_run_tumble = False
 gc_model = 'run-and-tumble'
 
 neuron_params = {
-    "dendrite_diameter": 3. * um,
-    "axon_diameter": 4. * um,
     "growth_cone_model": gc_model,
     "use_uniform_branching": use_uniform_branching,
     "use_van_pelt": use_vp,
@@ -86,12 +84,17 @@ neuron_params = {
 }
 
 dendrite_params = {
+    "initial_diameter": 3. * um,
     "use_van_pelt": use_vp,
     "growth_cone_model": gc_model,
     "speed_growth_cone": 0.2 * um / minute,
     "filopodia_wall_affinity": 10.,
     "persistence_length" : 200. * um,
     "taper_rate": 3./250.,
+}
+
+neurite_params = {
+    "axon": {"initial_diameter": 4. * um}, "dendrite": dendrite_params
 }
 
 
@@ -155,7 +158,7 @@ if __name__ == '__main__':
 
     print("Creating neurons")
     gids = ds.create_neurons(n=200, culture=culture, params=neuron_params,
-                            dendrites_params=dendrite_params, num_neurites=2)
+                            neurite_params=dendrite_params, num_neurites=2)
 
     start = time.time()
     fig, ax = plt.subplots()

--- a/examples/3chambers/3chambers.py
+++ b/examples/3chambers/3chambers.py
@@ -66,8 +66,6 @@ use_run_tumble = False
 gc_model = 'run-and-tumble'
 
 neuron_params = {
-    "dendrite_diameter": 3. * um,
-    "axon_diameter": 4. * um,
     "growth_cone_model": gc_model,
     "use_uniform_branching": use_uniform_branching,
     "use_van_pelt": use_vp,
@@ -77,7 +75,7 @@ neuron_params = {
     "filopodia_finger_length": 5. * um,
     "filopodia_min_number": 30,
     "persistence_length" : 600. * um,
-    "taper_rate": 2./1000.,
+    "taper_rate": 1./1000.,
 
     "soma_radius": soma_radius * um,
     'B' : 10. * cpm,
@@ -92,6 +90,7 @@ dendrite_params = {
     "filopodia_wall_affinity": 10.,
     "persistence_length" : 200. * um,
     "taper_rate": 3./250.,
+    "initial_diameter": 3. * um,
 }
 
 

--- a/examples/bugs/granular.py
+++ b/examples/bugs/granular.py
@@ -36,13 +36,9 @@ num_neurons = 5
 
 neuron_params = {
     # "growth_cone_model": "self_referential_forces",
-
-
     "filopodia_min_number": 30,
     "speed_growth_cone": 1.,
     "sensing_angle": 0.1495,
-    # "dendrite_diameter":20.,
-
 }
 
 dendrite_params = {

--- a/examples/neurons/bipolar_cell.py
+++ b/examples/neurons/bipolar_cell.py
@@ -38,8 +38,6 @@ num_neurons = 1
 
 
 neuron_params = {
-    "dendrite_diameter": 2.*um,
-    "axon_diameter": 3.*um,
     "position": np.random.uniform(-1000, 1000, (num_neurons, 2))*um,
     "retraction_probability": 1.,
     "somatropic_factor": 0.02,
@@ -54,6 +52,7 @@ axon_params = {
     # diameter
     "taper_rate": 1./300.,
     "diameter_ratio_avg": 0.5,
+    "initial_diameter": 3.*um,
     # branching
     "use_van_pelt": True,
     "B": 0.2*cpm,
@@ -65,6 +64,7 @@ dend_params = {
     "persistence_length": 250.*um,
     "speed_growth_cone": 0.01*um/minute,
     "taper_rate": 1./200.,
+    "initial_diameter": 2.*um,
     "use_uniform_branching": False,
     "use_van_pelt": True,
     "B": 1.*cpm,

--- a/examples/neurons/bipolar_cell_culture.py
+++ b/examples/neurons/bipolar_cell_culture.py
@@ -37,8 +37,6 @@ num_neurons = 1
 filename    = "bipolar-cell.swc"
 
 bip_nrn = {
-    "dendrite_diameter": 2.,
-    "axon_diameter": 3.,
     "description": "bipolar cell",
     "soma_radius": 8.,
     "position": [(0., 0.)]
@@ -49,6 +47,7 @@ bip_nrn = {
 # initial period (first 5 days)
 
 bip_axon_i = {
+    "initial_diameter": 3.,
     "persistence_length": 500.,
     "speed_growth_cone": 0.03,
     # diameter
@@ -62,6 +61,7 @@ bip_axon_i = {
 }
 
 bip_dend_i = {
+    "initial_diameter": 2.,
     "persistence_length": 250.,
     "speed_growth_cone": 0.01,
     "thinning_ratio": 1./300.,

--- a/examples/neurons/chandelier-cell.py
+++ b/examples/neurons/chandelier-cell.py
@@ -41,8 +41,6 @@ num_omp     = 1
 neuron_params = {
     "filopodia_min_number": 30,
     "sensing_angle": 0.1495*rad,
-    "dendrite_diameter": 2.*um,
-    "axon_diameter": 3.*um,
     "position": np.array([(0., 0.)])*um,
     "neurite_angles": {
         "axon": 275.*deg, "dendrite_1": 115.*deg, "dendrite_2": 65.*deg}
@@ -54,6 +52,7 @@ dend_params = {
 
     "persistence_length": 150.0*um,
     "taper_rate": 1./100.,
+    "initial_diameter": 2.*um,
     "speed_growth_cone": 0.008*um/minute,
 }
 
@@ -66,6 +65,7 @@ axon_params = {
     "filopodia_wall_affinity": 2.,
     "filopodia_finger_length": 50.0*um,
     "taper_rate": 1./200.,
+    "initial_diameter": 3.*um,
 
     "persistence_length": 300.0*um,
     "speed_growth_cone": 0.015*um/minute,

--- a/examples/neurons/granule_cell.py
+++ b/examples/neurons/granule_cell.py
@@ -35,13 +35,12 @@ num_neurons = 1
 
 
 neuron_params = {
-    "dendrite_diameter": 2. * um,
-    "axon_diameter": 3.5 * um,
     "position": np.random.uniform(-1000, 1000, (num_neurons, 2)) * um,
     "growth_cone_model": "simple-random-walk"
 }
 
 axon_params = {
+    "initial_diameter": 3.5 * um,
     "persistence_length": 200. * um,
     "speed_growth_cone": 0.04 * um / minute,
     # diameter
@@ -56,6 +55,7 @@ axon_params = {
 }
 
 dend_params = {
+    "initial_diameter": 2. * um,
     "taper_rate": 1.5/100.,
     "use_uniform_branching": True,
     "uniform_branching_rate": 0.0001 * cpm,

--- a/examples/neurons/multipolar-cell.py
+++ b/examples/neurons/multipolar-cell.py
@@ -38,8 +38,6 @@ num_omp     = 1
 neuron_params = {
     "filopodia_min_number": 30,
     "sensing_angle": 70.*deg,
-    "dendrite_diameter": 2.*um,
-    "axon_diameter": 3.5*um,
     "position": np.array([(0., 0.)])*um,
     "gc_split_angle_mean": 30.*deg,
     "soma_radius": 4.*um,
@@ -51,6 +49,7 @@ dend_params = {
 
     "persistence_length": 150.*um,
     "taper_rate": 1./130.,
+    "initial_diameter": 2.*um,
 
     # Cr model
     "res_retraction_factor": 0.07 * um/minute,
@@ -80,6 +79,7 @@ axon_params = {
     "filopodia_wall_affinity": 2.,
     "filopodia_finger_length": 10.*um,
     "taper_rate": 1./300.,
+    "initial_diameter": 3.5*um,
 
     "persistence_length": 250.*um,
 

--- a/examples/neurons/multipolar-cell2.py
+++ b/examples/neurons/multipolar-cell2.py
@@ -38,8 +38,6 @@ num_omp     = 1
 neuron_params = {
     "filopodia_min_number": 30,
     "sensing_angle": 0.1495,
-    "dendrite_diameter": 2.,
-    "axon_diameter": 3.,
     "position": np.array([(0., 0.)]),
     "neurite_angles": {"axon": 4.8, "dendrite_1": 2., "dendrite_2": 1.1}
 }
@@ -48,9 +46,10 @@ dend_params = {
     "growth_cone_model": gc_model,
     "use_van_pelt": True,
 
-    "persistence_length": 150.0,
-    "thinning_ratio": 1./100.,
-    "speed_growth_cone": 0.008,
+    "persistence_length": 150.0 * um,
+    "taper_rate": 1./100.,
+    "initial_diameter": 2. * um,
+    "speed_growth_cone": 0.008 * um / minute,
 
     # Best model
     "gc_split_angle_mean": 1.,
@@ -68,10 +67,11 @@ axon_params = {
 
     "filopodia_wall_affinity": 2.,
     "filopodia_finger_length": 50.0,
-    "thinning_ratio": 1./200.,
+    "taper_rate": 1./200.,
+    "initial_diameter": 3. * um,
 
-    "persistence_length": 300.0,
-    "speed_growth_cone": 0.015,
+    "persistence_length": 300.0 * um,
+    "speed_growth_cone": 0.015 * um / minute,
     "gc_split_angle_mean": 60.,
 
     # Best model

--- a/examples/neurons/purkinje.py
+++ b/examples/neurons/purkinje.py
@@ -44,8 +44,6 @@ neuron_params = {
     "filopodia_min_number": 15,
     "speed_growth_cone": 0.2 * um / minute,
     "sensing_angle": 0.1495 * rad,
-    "dendrite_diameter": 6.*um,
-    "axon_diameter": 3.*um,
     "position": (0., 0.)*um,
     "max_arbor_length": 20000.*um,
     "diameter_eta_exp": 20.,
@@ -55,6 +53,7 @@ neuron_params = {
 axon_params = {
     "persistence_length": 200.0 * um,
     "taper_rate": 1./400.,
+    "initial_diameter": 3.*um,
     "somatropic_scale": 500.*um,
     "somatropic_factor": 0.7,
     "self_avoidance_factor": 0.3,
@@ -67,6 +66,7 @@ dendrite_params = {
 
     "persistence_length": 100.0 * um,
     "taper_rate": 1./100.,
+    "initial_diameter": 6.*um,
     "diameter_fraction_lb": 0.8,
 
     # SFR parameters

--- a/examples/neurons/pyramidal_cell.py
+++ b/examples/neurons/pyramidal_cell.py
@@ -37,10 +37,6 @@ gc_model    = "self-referential-forces"
 
 
 neuron_params = {
-    # initial neurite shape parameters
-    "dendrite_diameter": 3.*um,
-    "axon_diameter": 4.*um,
-
     # soma position
     "position": np.random.uniform(-1000, 1000, (num_neurons, 2))*um,
 
@@ -71,6 +67,7 @@ axon_params = {
     # neurite shape paramters
     "taper_rate": 1./400.,
     "diameter_ratio_avg": 0.5,
+    "initial_diameter": 4.*um,
 
     # branching choice and parameter
     "use_van_pelt": False,
@@ -98,6 +95,7 @@ dend_params = {
 
     # neurite shape paramters
     "taper_rate": 1./150.,
+    "initial_diameter": 3.*um,
 
     # branching choice and parameters
     "use_uniform_branching": False,

--- a/examples/neurons/pyramidal_cell_culture.py
+++ b/examples/neurons/pyramidal_cell_culture.py
@@ -44,8 +44,6 @@ sim_time = 5 * day
 
 pyr_nrn = {
     "growth_cone_model" : 'cst_po_rt',
-    "dendrite_diameter": 3. * um,
-    "axon_diameter": 4. * um,
     "polarization_strength": 20.,
     "neurite_angles": {"axon": 1.57, "dendrite_1": 3.9, "dendrite_2": 5.5},
     "description": "pyramidal cell",
@@ -59,7 +57,8 @@ pyr_axon_i = {
     "persistence_length": 500. * um,
     "speed_growth_cone": 0.07 * um / minute,
     # diameter
-    #"thinning_ratio": 1./320.,
+    "initial_diameter": 4. * um,
+    "taper_rate": 1./320.,
     "diameter_ratio_avg": 0.5,
     # branching
     "use_van_pelt": False,
@@ -69,7 +68,8 @@ pyr_axon_i = {
 pyr_dend_i = {
     "persistence_length": 250. * um,
     "speed_growth_cone": 0.01 * um / minute,
-    #"thinning_ratio": 1./200.,
+    "taper_rate": 1./200.,
+    "initial_diameter": 3. * um,
     "use_uniform_branching": False,
     "use_van_pelt": True,
     "B": 1. * cpm,

--- a/examples/neurons/several_step_growth.py
+++ b/examples/neurons/several_step_growth.py
@@ -35,10 +35,6 @@ from dense.units import *
 # to all the neurites (dendrites and axon)
 # 
 neuron_params = {
-    # initial neurite shape parameters
-    "dendrite_diameter": 2.*um,
-    "axon_diameter": 1.*um,
-
     # soma position
     # "position": np.random.uniform(-1000, 1000, (num_neurons, 2))*um,
 
@@ -62,6 +58,7 @@ axon_params = {
     "speed_growth_cone": 0.05 *um/minute,
     "persistence_length": 200.* um,
     "taper_rate": 0.0001,
+    "initial_diameter": 1.*um,
 
     # branching choice and parameters
     "use_uniform_branching": False,
@@ -78,6 +75,7 @@ dendrite_params = {
     "filopodia_finger_length": 20. *um,
     "filopodia_min_number": 30,
     "taper_rate": 0.001,
+    "initial_diameter": 2.*um,
 
     # extension parameters
     "speed_growth_cone": 0.01 *um/minute,

--- a/examples/neurons/starbust_amacrine_cell.py
+++ b/examples/neurons/starbust_amacrine_cell.py
@@ -35,7 +35,6 @@ num_neurons = 1
 
 
 neuron_params = {
-    "dendrite_diameter": 2. * um,
     "soma_radius": 3. * um,
     "position": np.random.uniform(-1000, 1000, (num_neurons, 2)) * um,
     "has_axon": False,
@@ -43,6 +42,7 @@ neuron_params = {
 }
 
 dend_params = {
+    "initial_diameter": 2. * um,
     "sensing_angle": 45.*deg,
     "persistence_length": 25. * um,
     "speed_growth_cone": 0.01 * um/minute,

--- a/examples/patterns/patterns.py
+++ b/examples/patterns/patterns.py
@@ -53,8 +53,6 @@ neuron_params = {
     "persistence_length": 200. * um,
     "soma_radius": soma_radius,
     "retraction_probability": 0.1,
-    "axon_diameter": 2.*um,
-    "dendrite_diameter": 2.*um,
 }
 
 dendrite_params = {
@@ -64,6 +62,11 @@ dendrite_params = {
     "speed_growth_cone": 0.1 * um / minute,
     "filopodia_wall_affinity": 0.01,
     "persistence_length" : 100. * um,
+    "initial_diameter": 2.*um,
+}
+
+neurite_params = {
+    "axon": {"initial_diameter": 2.*um}, "dendrites": dendrite_params
 }
 
 
@@ -94,7 +97,8 @@ if __name__ == '__main__':
                             on_area=culture.non_default_areas.keys(),
                             neurites_on_area=True,
                             params=neuron_params,
-                            dendrites_params=dendrite_params,
+                            neurite_params=neurite_params,
+                            neurite_names=["axon", "dendrite_1", "dendrite_2"],
                             num_neurites=3)
 
     ds.plot.plot_neurons(show=False)

--- a/examples/patterns/simple_pattern.py
+++ b/examples/patterns/simple_pattern.py
@@ -50,13 +50,13 @@ neuron_params = {
     "filopodia_wall_affinity": 0.01,
     "filopodia_finger_length": 10. * um,
     "filopodia_min_number": 15,
-    "speed_growth_cone": 0.25 * um/minute,
-    "persistence_length": 200. * um,
     "soma_radius": soma_radius,
     "retraction_probability": 0.1,
-    "axon_diameter": 2.*um,
-    "dendrite_diameter": 2.*um,
     "affinity_axon_axon_other_neuron": 100.,
+}
+
+axon_params = {
+    "initial_diameter": 2.*um,
 }
 
 dendrite_params = {
@@ -66,7 +66,10 @@ dendrite_params = {
     "speed_growth_cone": 0.1*um/minute,
     "filopodia_wall_affinity": 0.01,
     "persistence_length" : 100. * um,
+    "initial_diameter": 2.*um,
 }
+
+neurite_params={"axon": axon_params, "dendrites": dendrite_params}
 
 
 '''
@@ -92,12 +95,14 @@ if __name__ == '__main__':
 
     gids = ds.create_neurons(n=int(0.8*num_neurons), culture=interior,
                              params=neuron_params,
-                             dendrites_params=dendrite_params,
+                             neurite_params=neurite_params,
+                             neurite_names=["axon", "dendrite_1", "dendrite_2"],
                              num_neurites=3)
 
     gids = ds.create_neurons(n=int(0.2*num_neurons), culture=exterior,
                              params=neuron_params,
-                             dendrites_params=dendrite_params,
+                             neurite_params=neurite_params,
+                             neurite_names=["axon", "dendrite_1", "dendrite_2"],
                              num_neurites=3)
 
     for i in range(2):

--- a/examples/rall_circle/granular.py
+++ b/examples/rall_circle/granular.py
@@ -36,12 +36,9 @@ num_neurons = 15
 
 neuron_params = {
     # "growth_cone_model": "self_referential_forces",
-
-
     "filopodia_min_number": 30,
     "speed_growth_cone": 1.,
     "sensing_angle": 0.1495,
-    # "dendrite_diameter":20.,
 
 }
 

--- a/examples/rall_circle/purkinje.py
+++ b/examples/rall_circle/purkinje.py
@@ -36,12 +36,9 @@ num_neurons = 1
 
 neuron_params = {
     # "growth_cone_model": "self_referential_forces",
-
-
     "filopodia_min_number": 30,
     "speed_growth_cone": 1.,
     "sensing_angle": 0.1495,
-    "dendrite_diameter":20.,
 
 }
 

--- a/examples/tutorials/2_interacting-neurons.py
+++ b/examples/tutorials/2_interacting-neurons.py
@@ -53,7 +53,7 @@ neuron_params = {
 }
 
 neurite_params = {
-    "axon": {"initial_diameter": 4.*um}
+    "axon": {"initial_diameter": 4.*um},
     "dendrites": {"taper_rate": 1./200., "initial_diameter": 3.*um}
 }
 

--- a/examples/tutorials/2_interacting-neurons.py
+++ b/examples/tutorials/2_interacting-neurons.py
@@ -43,8 +43,6 @@ simu_params   = {
 }
 
 neuron_params = {
-    "axon_diameter": 4.*um,
-    "dendrite_diameter": 3.*um,
     "growth_cone_model": "simple-random-walk",
     "position": [(0., 0.), (100., 100.)]*um,
     "persistence_length": 200.*um,
@@ -54,7 +52,10 @@ neuron_params = {
     "uniform_branching_rate": 0.009*cph,
 }
 
-neurite_params = {"dendrites": {"taper_rate": 1./200.}}
+neurite_params = {
+    "axon": {"initial_diameter": 4.*um}
+    "dendrites": {"taper_rate": 1./200., "initial_diameter": 3.*um}
+}
 
 # configure DeNSE
 ds.set_kernel_status(simu_params)

--- a/examples/tutorials/3_space-embedding.py
+++ b/examples/tutorials/3_space-embedding.py
@@ -63,8 +63,6 @@ pos = env.seed_neurons(num_neurons, soma_radius=soma_radius, unit="um",
                        return_quantity=False)
 
 neuron_params = {
-    "axon_diameter": 4.*um,
-    "dendrite_diameter": 3.*um,
     "growth_cone_model": "simple-random-walk",
     "position": [tuple(p) for p in pos]*um,
     "persistence_length": 200.*um,
@@ -77,11 +75,13 @@ neuron_params = {
 axon_params = {
     "max_arbor_length": 1.*cm,
     "taper_rate": 1./400.,
+    "initial_diameter": 4.*um,
 }
 
 dend_params = {
     "max_arbor_length": 500.*um,
     "taper_rate": 1./200.,
+    "initial_diameter": 3.*um,
 }
 
 neurite_params = {"axon": axon_params, "dendrite": dend_params}

--- a/src/elements/Neurite.cpp
+++ b/src/elements/Neurite.cpp
@@ -74,6 +74,7 @@ Neurite::Neurite(const std::string &name, const std::string &neurite_type,
     , max_gc_num_(MAX_GC_NUM)
     , max_arbor_len_(MAX_ARBOR_LENGTH)
     , fixed_arbor_len_(0.)
+    , initial_diameter_(NEURITE_DIAMETER)
     // parameters for van Pelt branching
     , lateral_branching_angle_mean_(LATERAL_BRANCHING_ANGLE_MEAN)
     , lateral_branching_angle_std_(LATERAL_BRANCHING_ANGLE_STD)
@@ -148,10 +149,9 @@ Neurite::~Neurite()
  * @param neurite_name
  */
 void Neurite::init_first_node(BaseWeakNodePtr soma, const BPoint &pos,
-                              const std::string &name, double soma_radius,
-                              double neurite_diameter)
+                              const std::string &name, double soma_radius)
 {
-    auto firstNode = std::make_shared<Node>(soma, 0., pos, neurite_diameter,
+    auto firstNode = std::make_shared<Node>(soma, 0., pos, initial_diameter_,
                                             shared_from_this());
 
     firstNode->centrifugal_order_ = 0;
@@ -1237,6 +1237,15 @@ void Neurite::get_distances(stype node, stype segment, double &dist_to_parent,
 }
 
 
+void Neurite::update_initial_diameter(double diameter)
+{
+    initial_diameter_ = diameter;
+
+    nodes_[0]->set_diameter(diameter);
+    growth_cones_[1]->set_diameter(diameter);
+}
+
+
 //###################################################
 //                  get/set status
 //###################################################
@@ -1244,6 +1253,8 @@ void Neurite::get_distances(stype node, stype segment, double &dist_to_parent,
 
 void Neurite::set_status(const statusMap &status)
 {
+    bool sim_started  = (kernel().simulation_manager.get_time() != Time());
+
     get_param(status, names::max_gc_number, max_gc_num_);
     get_param(status, names::max_arbor_length, max_arbor_len_);
 
@@ -1253,8 +1264,28 @@ void Neurite::set_status(const statusMap &status)
     get_param(status, names::gc_split_angle_mean, gc_split_angle_mean_);
     get_param(status, names::gc_split_angle_std, gc_split_angle_std_);
 
-    get_param(status, names::speed_decay_factor, gc_speed_decay_);    
+    get_param(status, names::speed_decay_factor, gc_speed_decay_);
 
+    // initial diameter
+    double init_diam = initial_diameter_;
+
+    bool bid = get_param(status, names::initial_diameter, init_diam);
+
+    if (bid and init_diam != initial_diameter_)
+    {
+        if (sim_started)
+        {
+            throw InvalidArg("Cannot change the initial diameter for a neurite "
+                             " after simulation start.",
+                             __FUNCTION__, __FILE__, __LINE__);
+        }
+        else
+        {
+            update_initial_diameter(init_diam);
+        }
+    }
+
+    // taper rate
     double tr;
     bool tr_set = get_param(status, names::taper_rate, tr);
 
@@ -1370,6 +1401,11 @@ void Neurite::get_status(statusMap &status, const std::string &level) const
     if (level == "neurite")
     {
         set_param(status, names::neurite_type, neurite_type_, "");
+
+        set_param(status, names::taper_rate, taper_rate_, "");
+        set_param(status, names::initial_diameter, initial_diameter_,
+                  "micrometer");
+
         set_param(status, names::diameter_fraction_lb, diam_frac_lb_, "");
         set_param(status, names::gc_split_angle_mean, gc_split_angle_mean_,
                   "rad");
@@ -1381,7 +1417,6 @@ void Neurite::get_status(statusMap &status, const std::string &level) const
                   lateral_branching_angle_mean_, "rad");
         set_param(status, names::observables, observables_, "");
 
-        set_param(status, names::taper_rate, taper_rate_, "1 / micrometer");
         set_param(status, names::diameter_ratio_std, diameter_ratio_std_, "");
         set_param(status, names::diameter_ratio_avg, diameter_ratio_avg_, "");
         set_param(status, names::diameter_eta_exp, diameter_eta_exp_, "");

--- a/src/elements/Neurite.hpp
+++ b/src/elements/Neurite.hpp
@@ -93,8 +93,7 @@ class Neurite : public std::enable_shared_from_this<Neurite>
 
     // Init and finalize functions
     void init_first_node(BaseWeakNodePtr soma, const BPoint &pos,
-                         const std::string &neurite_name, double soma_radius,
-                         double neurite_diameter);
+                         const std::string &neurite_name, double soma_radius);
     void set_soma_angle(const double angle);
     double get_soma_angle() const;
     void finalize();
@@ -157,6 +156,7 @@ class Neurite : public std::enable_shared_from_this<Neurite>
     void add_node(NodePtr);
 
     void update_gc_speed();
+    void update_initial_diameter(double diameter);
 
     bool walk_tree(NodeProp &np) const;
     simple_gc_range active_gc_range() const;
@@ -201,6 +201,7 @@ class Neurite : public std::enable_shared_from_this<Neurite>
     std::string neurite_type_;
     double taper_rate_; // diameter thinning with distance
     double min_diameter_;
+    double initial_diameter_;
     double gc_speed_decay_;
 
     // competition

--- a/src/elements/Neuron.hpp
+++ b/src/elements/Neuron.hpp
@@ -44,19 +44,6 @@
 namespace growth
 {
 
-typedef struct NeuronDetails
-{
-    double soma_radius;
-    double dendrite_diameter;
-    double axon_diameter;
-    NeuronDetails()
-        : soma_radius(SOMA_RADIUS)
-        , dendrite_diameter(DENDRITE_DIAMETER)
-        , axon_diameter(AXON_DIAMETER)
-    {
-    }
-} NeuronDetails;
-
 
 /*
  *  Friend classes forward declaration
@@ -153,8 +140,7 @@ class Neuron : public std::enable_shared_from_this<Neuron>
     NeuriteMap neurites_;
     BaseNodePtr soma_;
     bool has_axon_;
-    //! Center of mass of the neuron's soma
-    NeuronDetails details;
+    double soma_radius_;
     // obserables for recorders
     std::vector<std::string> observables_;
     // Actin waves

--- a/src/libgrowth/growth_names.cpp
+++ b/src/libgrowth/growth_names.cpp
@@ -57,7 +57,6 @@ const std::string
 const std::string
     affinity_dendrite_soma_same_neuron("affinity_dendrite_soma_same_neuron");
 const std::string axon_angle("axon_angle");
-const std::string axon_diameter("axon_diameter");
 const std::string axon_polarization_weight("axon_polarization_weight");
 
 const std::string B("B");
@@ -67,7 +66,6 @@ const std::string critical_pull("critical_pull");
 
 const std::string memory_decay_factor("memory_decay_factor");
 const std::string dendrite_angles("dendrite_angles");
-const std::string dendrite_diameter("dendrite_diameter");
 const std::string description("description");
 const std::string diameter_eta_exp("diameter_eta_exp");
 const std::string diameter_fraction_lb("diameter_fraction_lb");
@@ -91,6 +89,7 @@ const std::string growth_cone_model("growth_cone_model");
 const std::string has_axon("has_axon");
 
 const std::string initial_branch_lenght("initial_branch_lenght");
+const std::string initial_diameter("initial_diameter");
 const std::string interactions("interactions");
 
 const std::string lateral_branching_angle_mean("lateral_branching_angle_mean");

--- a/src/libgrowth/growth_names.hpp
+++ b/src/libgrowth/growth_names.hpp
@@ -58,8 +58,7 @@ extern const std::string max_arbor_length;
 
 extern const std::string active;
 
-extern const std::string axon_diameter;
-extern const std::string dendrite_diameter;
+extern const std::string initial_diameter;
 //! axon angle set to perform experiments
 extern const std::string axon_angle;
 //! initial branching lenght        0     [micrometers]
@@ -75,8 +74,7 @@ extern const std::string diameter_eta_exp;
 
 
 #define BRANCHING_PROBA_DEFAULT 0.05
-#define AXON_DIAMETER 2.
-#define DENDRITE_DIAMETER 2.
+#define NEURITE_DIAMETER 2.
 #define SOMA_RADIUS 5.
 #define THINNING_RATIO 0.002 // lose 1 micrometer every 500 micrometers
 #define MIN_DIAMETER 0.05     // diameter when a gc stops growing [micrometers]

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -55,7 +55,7 @@ def test_create_neurites_one_neuron():
     neuron = ds.create_neurons()
 
     neurite_params = {
-        "axon": {"speed_growth_cone": 0.1*um/minute},
+        "axon": {"speed_growth_cone": 0.1*um/minute, "initial_diameter": 1.*um},
         "dendrite1": {"speed_growth_cone": 0.02*um/minute},
         "dendrite2": {"speed_growth_cone": 0.03*um/minute}
     }
@@ -65,6 +65,7 @@ def test_create_neurites_one_neuron():
     assert len(neuron.neurites) == 3
     assert set(neuron.dendrites.keys()) == {"dendrite1", "dendrite2"}
     assert neuron.axon.speed_growth_cone == 0.1*um/minute
+    assert neuron.axon.initial_diameter == 1.*um
     assert neuron.dendrite1.speed_growth_cone == 0.02*um/minute
     assert neuron.dendrite2.speed_growth_cone == 0.03*um/minute
 

--- a/tests/test_diameter.py
+++ b/tests/test_diameter.py
@@ -38,8 +38,9 @@ def test_initial_diam():
 
     # create one neuron
     neuron = ds.create_neurons(num_neurites=1,
-                               params={"axon_diameter": diam})
+                               params={"initial_diameter": diam})
 
+    assert neuron.axon.initial_diameter == diam
     assert neuron.axon.branches[0].diameter == diam
 
 
@@ -51,11 +52,15 @@ def test_final_diam():
 
     taper = 0.005
 
+    neurite_params = {
+        "axon": {"initial_diameter": diam_axon},
+        "dendrite_1": {"initial_diameter": diam_dend}
+    }
+
     # create one neuron
     neuron = ds.create_neurons(num_neurites=2,
-                               params={"axon_diameter": diam_axon,
-                                       "dendrite_diameter": diam_dend,
-                                       "taper_rate": taper})
+                               params={"taper_rate": taper},
+                               neurite_params=neurite_params)
 
     ds.simulate(100.*minute)
 
@@ -65,7 +70,9 @@ def test_final_diam():
     daxon_th = diam_axon - len_axon*taper
     ddend_th = diam_dend - len_dend*taper
 
+    assert np.isclose(neuron.axon.initial_diameter.m, diam_axon.m)
     assert np.isclose(neuron.axon.branches[0].diameter.m, daxon_th.m)
+    assert np.isclose(neuron.dendrite_1.initial_diameter.m, diam_dend.m)
     assert np.isclose(
         neuron.dendrites["dendrite_1"].branches[0].diameter.m,
         ddend_th.m)


### PR DESCRIPTION
Fixes #23 by moving diameter to neurite level,introducing new ``"initial_diameter"`` keyword instead of previous ``"axon_diameter"`` and ``"dendrite_diameter"`` at neuron level.
This enables custom diameter for each neurite.