### PR TITLE
Move to C++14 and minor maintenance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,11 +104,6 @@ IF ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
 ELSEIF ( ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local") AND NOT ("$CACHE{CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local"))
     set( CMAKE_INSTALL_PREFIX "$CACHE{CMAKE_INSTALL_PREFIX}" )
     set( PYTHON_INSTALL_DIR "$CACHE{PYTHON_INSTALL_DIR}" )
-ELSEIF ( "${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local" )
-  # /usr/local is forbidden because it is the default CMAKE value and it makes
-  # configuration too complex
-    message( FATAL_ERROR "Do not install into '/usr/local'. "
-             "Please change CMAKE_INSTALL_PREFIX." )
 ELSE ()
   # make sure we get the absolute path
   get_filename_component(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" ABSOLUTE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
-cmake_minimum_required( VERSION 2.6 )
+cmake_minimum_required( VERSION 2.9 )
 
 # add cmake modules: for all `include(...)` first look here
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
@@ -44,10 +44,10 @@ get_target_triple( CGROWTH_TARGET_TRIPLE CGROWTH_TARGET_ARCH CGROWTH_TARGET_VEND
 
 # process compiler and options
 if (MSVC)
-   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /Zc:twoPhase- /Ox" )
+   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /Zc:twoPhase- /Ox /std:c++14" )
    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj")
 else ()
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11" )
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14" )
 
     if (CYGWIN AND CMAKE_COMPILER_IS_GNUCC)
        set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -U__STRICT_ANSI__" )

--- a/INSTALL
+++ b/INSTALL
@@ -28,7 +28,7 @@ Before installation, several tools must be pre-installed, including
 
 1. A set of software and libraries
     * CMake
-    * A C and C++11-compliant compiler such as GCC (4.8.1+)
+    * A C and C++14-compliant compiler such as GCC (6.1+)
     * Python (2.7 or 3.3+) and its header/development files
     * GEOS (3.5+) and its header/development files
     * Boost Geometry and Range (Boost 1.62 or higher)

--- a/src/pymodule/dense/_helpers.py
+++ b/src/pymodule/dense/_helpers.py
@@ -250,12 +250,6 @@ def nonstring_container(obj):
     '''
     if not isinstance(obj, _container):
         return False
-
-    try:
-        if isinstance(obj, unicode):
-            return False
-    except NameError:
-        pass
     
     if isinstance(obj, bytes):
         return False
@@ -460,10 +454,7 @@ def to_cppunit(val, valname):
 # ----------------- #
 
 def is_string(value):
-    try:
-        return isinstance(value, (str, bytes, unicode))
-    except:
-        return isinstance(value, (str, bytes))
+    return isinstance(value, (str, bytes))
 
 
 def is_scalar(value):

--- a/src/pymodule/setup.py.in
+++ b/src/pymodule/setup.py.in
@@ -54,9 +54,10 @@ copt =  {
         '/openmp', '/Od', '/fp:precise', '/permissive-', '/Zc:twoPhase-',
         '/MDd' if "@CMAKE_BUILD_TYPE@" == "Debug" else "/MD", "-Zi", "/Ox",
         '/D_ITERATOR_DEBUG_LEVEL=2' if "@CMAKE_BUILD_TYPE@" == "Debug" else "",
+        '/std:c++14',
     ],
     'unix': [
-        '-std=c++11', '-Wno-cpp', '-Wno-unused-function', '-fopenmp',
+        '-std=c++14', '-Wno-cpp', '-Wno-unused-function', '-fopenmp',
         '-ffast-math', '-msse', '-ftree-vectorize', '-O2', '-g', "-fPIC",
     ],
 }


### PR DESCRIPTION
This PR moves the C++ version used to C++14 to ensure compatibility with future Boost versions.
It also lets users install to ``/usr/local`` and removes some lingering calls to unicode.