### PR TITLE
Improve access to properties from python objects (Neuron, Population)

### DIFF
--- a/examples/models/neurons/bipolar_cell.py
+++ b/examples/models/neurons/bipolar_cell.py
@@ -148,7 +148,12 @@ ds.plot.plot_neurons(show=True)
 # I/O of morphology files
 
 n.to_swc("bipolar_cell.swc")
-n.to_neuroml("bipolar_cell.nml")
+
+try:
+    import neuroml
+    n.to_neuroml("bipolar_cell.nml")
+except ImportError:
+    pass
 
 
 # Example of analysis, loading into neuroml for visualization and analysis

--- a/examples/models/neurons/chandelier-cell.py
+++ b/examples/models/neurons/chandelier-cell.py
@@ -162,8 +162,6 @@ lb = {
 }
 
 neurite_params = {"axon": lb_a, "dendrites": lb}
-# axon_params.update(lb_a)
-# dend_params.update(lb)
 
 ds.set_object_properties(n, neurite_params=neurite_params)
 
@@ -189,7 +187,11 @@ ds.io.save_to_swc("chandelier-cell.swc", gid=n, resolution=50)
 
 ds.plot.plot_dendrogram(n.axon)
 
-print("Asymmetry of the axon:", ds.morphology.tree_asymmetry(n.axon))
+try:
+    import neurom
+    print("Asymmetry of the axon:", ds.morphology.tree_asymmetry(n.axon))
 
-print("Asymmetry of a dendrite:",
-      ds.morphology.tree_asymmetry(n.dendrites["dendrite_2"]))
+    print("Asymmetry of a dendrite:",
+          ds.morphology.tree_asymmetry(n.dendrites["dendrite_2"]))
+except ImportError:
+    pass

--- a/examples/models/neurons/granule_cell.py
+++ b/examples/models/neurons/granule_cell.py
@@ -121,18 +121,17 @@ try:
 
     for ax in fig.axes:
         ax.set_title("")
+
+    tree2 = n.axon.get_tree()
+
+    print(tree2.neuron, tree2.neurite)
+
+    plt.axis('off')
+
+    fig.suptitle("")
+
+    plt.tight_layout()
+
+    plt.show()
 except ImportError:
     pass
-
-
-tree2 = n.axon.get_tree()
-
-print(tree2.neuron, tree2.neurite)
-
-plt.axis('off')
-
-fig.suptitle("")
-
-plt.tight_layout()
-
-plt.show()

--- a/examples/tutorials/2_interacting-neurons.py
+++ b/examples/tutorials/2_interacting-neurons.py
@@ -100,5 +100,10 @@ ds.plot.plot_neurons()
 
 # In the swc format
 ds.io.save_to_swc("neurons.swc", n)
+
 # In the Neurom format
-ds.io.save_to_neuroml("neurons.nml", n)
+try:
+    import neuroml
+    ds.io.save_to_neuroml("neurons.nml", n)
+except ImportError:
+    pass

--- a/src/elements/Neuron.cpp
+++ b/src/elements/Neuron.cpp
@@ -160,20 +160,6 @@ void Neuron::init_status(
                                    "False.", __FUNCTION__, __FILE__,
                                    __LINE__);
         }
-
-        if (neurite_statuses.find("dendrites") == neurite_statuses.end())
-        {
-            for (auto p : neurite_statuses)
-            {
-                if (neurite_names.find(p.first) == neurite_names.end())
-                {
-                    throw InvalidParameter(
-                        "`neurite_names` and the parameters contain "
-                        "different  neurite names.", __FUNCTION__,
-                        __FILE__, __LINE__);
-                }
-            }
-        }
     }
 
     std::unordered_map<std::string, double> nas;

--- a/src/pymodule/dense/_pygrowth.pyx
+++ b/src/pymodule/dense/_pygrowth.pyx
@@ -1756,8 +1756,23 @@ cdef _create_neurons(dict params, dict neurite_params,
     dod = (neurite_params
            and isinstance(next(iter(neurite_params.values())), dict))
 
+    # check that neurite names and neurite_params entries correspond
+    all_neurite_names = set()
+
+    for entry in neurite_names:
+        if nonstring_container(entry):
+            all_neurite_names.update(entry)
+        else:
+            all_neurite_names.add(entry)
+
     if not dod:
-        neurite_params = {k: neurite_params for k in neurite_names}
+        neurite_params = {
+            name: neurite_params.copy() for name in all_neurite_names
+        }
+    elif "dendrites" not in neurite_params:
+        if not all_neurite_names.issuperset(neurite_params):
+            raise ValueError("There are entries in `neurite_params` that do "
+                             "not correspond to an existing neurite.")
 
     for key, value in neurite_params.items():
         base_neurite_statuses[_to_bytes(key)] = \

--- a/src/pymodule/dense/elements.py
+++ b/src/pymodule/dense/elements.py
@@ -1009,14 +1009,17 @@ class Population(list):
         return pop
 
     def __init__(self, population=None, info=None, name="no_name"):
-        self.info     = info
-        self.name     = name
+        self.info = info
+        self.name = name
+
         if population is not None:
             super(Population, self).__init__(population)
         else:
             super(Population, self).__init__()
+
         self.sort()
         self._idx = {}  # converter from gid to idx
+
         for i, n in enumerate(self):
             self._idx[int(n)] = i
 
@@ -1042,10 +1045,16 @@ class Population(list):
 
     def __getattr__(self, attribute):
         ''' Access neuronal properties directly '''
+        if attribute.startswith("_"):
+            return self.__getattribute__(attribute)
+
         return {int(n): getattr(n, attribute) for n in self}
 
     def __setattr__(self, attribute, value):
         ''' Set neuronal properties directly '''
+        if attribute.startswith("_"):
+            return super().__setattr__(attribute, value)
+
         [setattr(n, attribute, value) for n in self]
 
     @property

--- a/src/pymodule/dense/elements.py
+++ b/src/pymodule/dense/elements.py
@@ -524,6 +524,8 @@ class Neurite(object):
 
         if attribute in ndict:
             return ndict[attribute]
+        elif attribute in ndict.get("observables", {}):
+            return self.get_state(attribute)
 
         super(Neurite, self).__getattribute__(attribute)
 
@@ -1037,6 +1039,14 @@ class Population(list):
             return pop
         else:
             return super(Population, self).__getitem__(self._idx[key])
+
+    def __getattr__(self, attribute):
+        ''' Access neuronal properties directly '''
+        return {int(n): getattr(n, attribute) for n in self}
+
+    def __setattr__(self, attribute, value):
+        ''' Set neuronal properties directly '''
+        [setattr(n, attribute, value) for n in self]
 
     @property
     def size(self):

--- a/src/pymodule/dense/elements.py
+++ b/src/pymodule/dense/elements.py
@@ -115,6 +115,8 @@ class Neuron(object):
 
             if attribute in ndict:
                 return ndict[attribute]
+            elif attribute in ndict.get("observables", {}):
+                return self.get_state(attribute)
 
         raise AttributeError(
             "{!r} has not attribute '{}'".format(self, attribute))
@@ -1019,15 +1021,19 @@ class Population(list):
     def __getitem__(self, key):
         if isinstance(key, slice):
             pop = Population(name="subpop_" + self.name)
+
             for i in range(self._idx[key.start], self._idx[key.stop]):
                 super(Population, pop).append(
                     super(Population, self).__getitem__(i))
+
             return pop
         elif _nsc(key):
             pop = Population(name="subpop_" + self.name)
+
             for i in key:
                 super(Population, pop).append(
                     super(Population, self).__getitem__(self._idx[i]))
+
             return pop
         else:
             return super(Population, self).__getitem__(self._idx[key])
@@ -1158,8 +1164,9 @@ class Population(list):
             Properties of the objects' status: a single value if
             `property_name` was specified, the full status ``dict`` otherwise.
         '''
-        return _pg.get_object_properties(self, property_name=property_name,
-                                         level=level, neurite=neurite)
+        return _pg.get_object_properties(
+            list(self), property_name=property_name, level=level,
+            neurite=neurite)
 
     def set_properties(self, params=None, axon_params=None,
                        dendrites_params=None):

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# test_properties.py
+#
+# This file is part of DeNSE.
+#
+# Copyright (C) 2019 SeNEC Initiative
+#
+# DeNSE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# DeNSE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DeNSE. If not, see <http://www.gnu.org/licenses/>.
+
+
+""" Testing access of object properties """
+
+import dense as ds
+from dense.units import *
+
+
+def test_neuron_neurite():
+    '''
+    Create neurons and neurites
+    '''
+    ds.reset_kernel()
+
+    neuron_params = {
+        "polarization_strength": 6.3,
+        "soma_radius": 3.*um,
+        "taper_rate": 0.005,
+    }
+
+    # create one neuron
+    neuron = ds.create_neurons(params=neuron_params, num_neurites=1)
+
+    assert neuron.polarization_strength == 6.3
+    assert neuron.soma_radius == 3.*um
+    assert neuron.num_growth_cones == 1.
+    assert neuron.soma_radius == neuron.get_properties("soma_radius")
+
+    axon = neuron.axon
+    
+    assert axon.taper_rate == 0.005
+
+    neuron.create_neurites(names=["dendrite"])
+
+    assert neuron.num_growth_cones == 2.
+    assert axon.num_growth_cones == 1.
+
+
+def test_population():
+    '''
+    Check get/set attributes on populations
+    '''
+    ds.reset_kernel()
+
+    num_neurons = 10
+    num_neurites = [i for i in range(num_neurons)]
+
+    pop = ds.create_neurons(num_neurons, num_neurites=num_neurites)
+
+    res = {i: float(j) for i, j in zip(range(num_neurons), num_neurites)}
+
+    assert pop.num_growth_cones == res
+
+    polarization_strength = 2.4
+
+    pop.polarization_strength = polarization_strength
+
+    res = {i: polarization_strength for i in range(num_neurons)}
+
+    assert pop.polarization_strength == res
+
+
+if __name__ == "__main__":
+    test_neuron_neurite()
+    test_population()


### PR DESCRIPTION
Fixes #55 and make status values directly gettable as (e.g.) ``neuron.num_growth_cones``.