### PR TITLE
Adaptively add objects during growth

### DIFF
--- a/docs/user/tutorial.rst
+++ b/docs/user/tutorial.rst
@@ -157,7 +157,7 @@ you can seed the random number generators used during the simulation through: ::
     ds.set_kernel_status({"seeds": [1, 5, 3, 6]})
 
 Note that one seed must be given for each thread.
-The result of a simulation should alawys be the same provided the number of threads and seeds used are
+The result of a simulation should always be the same provided the number of threads and seeds used are
 identical.
 
 
@@ -174,10 +174,19 @@ To increase speed, several approaches may or may not be attractive to you.
   advantage because it increases the size of the compartments composing the neuron, thus
   reducing their number and speeding up the interactions. However, this will obviously make the
   final results more "crude", as you subsample the real path of the neurites.
+* Increase the value of the ``"growth_threshold_polygon"`` kernel parameter; this parameter is
+  related to the distance the growth cone must move away from its previous position for a polygon
+  to be generated, at which point other growth cones will be able to interact with this new part
+  of the branch. This brings speedups that are similar to increasing time resolution for the same
+  reason mentioned previously: fewer geometric operations and polygons to deal with.
+  Note that increasing this value could lead to approximations: growth cones that should
+  have interacted may miss one another if you increase this value too far (over a few microns,
+  for instance), though it remains very low for values below a micron.
 * Switch the interactions off using ``ds.set_kernel_status({"interactions": False})``.
   Neuron-neuron interactions are currently the main source of CPU requirement and, though we know
-  how we could reduce it, it is a non-trivial task for which we currently do not have the
-  necessary time. If you are interested an would like to help on that, feel free to contact us.
+  how we could reduce them further, it is a non-trivial task for which we currently do not have
+  the necessary time. If you are interested an would like to help on that, feel free to contact
+  us.
 * Do not use a spatial environment. Though this leads to lower speed gains compared to the other
   solutions, it might also help in specific cases.
 
@@ -258,12 +267,21 @@ associated names:
     :language: python
     :lines: 118-120
 
+Because simulating many neurons can take time, in this example we set the
+kernel parameters so that neuron-neuron interactions are ignored and the
+progress of the simulation is printed:
+
+.. literalinclude:: ../../examples/tutorials/4_complex_neuron_params.py
+    :linenos:
+    :language: python
+    :lines: 153-160
+
 Finally we set the parameters and create the neurons:
 
 .. literalinclude:: ../../examples/tutorials/4_complex_neuron_params.py
     :linenos:
     :language: python
-    :lines: 164-169
+    :lines: 165-169
 
 If you run the whole file, you will get the following structure (scale bar is
 50 :math:`\mu m`):

--- a/examples/tutorials/4_complex_neuron_params.py
+++ b/examples/tutorials/4_complex_neuron_params.py
@@ -153,7 +153,8 @@ start = time.time()
 kernel_params = {
     "resolution": resolution,
     "num_local_threads": num_omp,
-    "interactions": False
+    "interactions": False,
+    "print_progress": True
 }
 
 ds.set_kernel_status(kernel_params)

--- a/src/elements/Branching.cpp
+++ b/src/elements/Branching.cpp
@@ -299,45 +299,82 @@ void Branching::update_splitting_cones(TNodePtr branching_cone,
     GCPtr old_cone   = std::dynamic_pointer_cast<GrowthCone>(branching_cone);
     BranchPtr branch = new_node->get_branch();
 
-    // to prevent overlap between the two second_cones, we put them on the two
-    // corners (last points) of the branch
-    std::pair<BPoint, BPoint> lps = branch->get_last_points();
-    double new_angle              = second_cone->get_state("angle");
-    double module                 = branch->get_last_segment_length();
-
-    BPoint lp1(lps.first), lp2(lps.second);
+    // to prevent overlap between the two second_cones, we put them in between
+    // the previous position and the two corners (last points) of the branch
+    double new_angle(second_cone->get_state("angle")), module;
     BPoint pos = second_cone->get_position();
+
+    BPoint lp1, lp2;
+
+    if (old_cone->cumul_dist_ > 0)
+    {
+        module = old_cone->cumul_dist_;
+
+        // compute what would be the last points
+        BPoint old_pos = branch->xy_at(branch->size() - 1);
+        BPoint l_vec = pos;
+        bg::subtract_point(l_vec, old_pos);
+
+        // orthogonal vector
+        double inv_norm =
+            1. / sqrt(l_vec.x() * l_vec.x() + l_vec.y() * l_vec.y());
+
+        double radius = 0.5*old_cone->get_diameter();
+
+        BPoint r_vec(-radius * l_vec.y() * inv_norm,
+                     radius * l_vec.x() * inv_norm);
+
+        lp1 = BPoint(pos.x() + r_vec.x(), pos.y() + r_vec.y());
+        lp2 = BPoint(pos.x() - r_vec.x(), pos.y() - r_vec.y());
+    }
+    else
+    {
+        std::pair<BPoint, BPoint> lps = branch->get_last_points();
+
+        module = branch->get_last_segment_length();
+
+        lp1 = lps.first;
+        lp2 = lps.second;
+    }
+
     BPoint tmp = BPoint(pos.x() + module * cos(new_angle),
                         pos.y() + module * sin(new_angle));
 
     double d1(bg::distance(tmp, lp1)), d2(bg::distance(tmp, lp2));
-    BPoint pos1 = BPoint(0.5 * (pos.x() + lp1.x()), 0.5 * (pos.y() + lp1.y()));
-    BPoint pos2 = BPoint(0.5 * (pos.x() + lp2.x()), 0.5 * (pos.y() + lp2.y()));
+    BPoint pos1 = BPoint(0.5 * (pos.x() + lp1.x()),
+                         0.5 * (pos.y() + lp1.y()));
+
+    BPoint pos2 = BPoint(0.5 * (pos.x() + lp2.x()),
+                         0.5 * (pos.y() + lp2.y()));
 
     if (d2 > d1)
     {
         std::swap(pos1, pos2);
     }
 
-    // make the two cones start from the parent position and end on lp1/lp2
     int omp_id = kernel().parallelism_manager.get_thread_local_id();
 
-    // remove last point (previous position) from old branch
-    BPolygonPtr last_seg = branch->get_last_segment();
-    branch->retract();
-    new_node->set_position(branch->get_last_xy());
-
-    if (last_seg != nullptr)
+    // remove last segment (if it was added)
+    if (old_cone->cumul_dist_ > 0)
     {
-        BBox box;
-        bg::envelope(*(last_seg.get()), box);
+        // remove last point (previous position) from old branch
+        BPolygonPtr last_seg = branch->get_last_segment();
+        branch->retract();
+        new_node->set_position(branch->get_last_xy());
 
-        // the last segment is initial size - 2 i.e. new size - 1
-        ObjectInfo info = std::make_tuple(
-            neurite_->get_parent_neuron().lock()->get_gid(),
-            neurite_->get_name(), new_node->get_node_id(), branch->size() - 1);
+        if (last_seg != nullptr)
+        {
+            BBox box;
+            bg::envelope(*(last_seg.get()), box);
 
-        kernel().space_manager.remove_object(box, info, omp_id);
+            // the last segment is initial size - 2 i.e. new size - 1
+            ObjectInfo info = std::make_tuple(
+                neurite_->get_parent_neuron().lock()->get_gid(),
+                neurite_->get_name(), new_node->get_node_id(),
+                branch->size() - 1);
+
+            kernel().space_manager.remove_object(box, info, omp_id);
+        }
     }
 
     tmp          = branch->get_last_xy();

--- a/src/elements/GrowthCone.cpp
+++ b/src/elements/GrowthCone.cpp
@@ -107,6 +107,7 @@ GrowthCone::GrowthCone(const std::string &model)
     , max_sensing_angle_(MAX_SENSING_ANGLE)
     , scale_up_move_(SCALE_UP_MOVE)
     , old_angle_(0.)
+    , cumul_angle_(0.)
     , cumul_dist_(0.)
     , threshold_(0.)
 {
@@ -155,6 +156,7 @@ GrowthCone::GrowthCone(const GrowthCone &copy)
     , min_filopodia_(copy.min_filopodia_)
     , num_filopodia_(copy.num_filopodia_)
     , old_angle_(copy.old_angle_)
+    , cumul_angle_(0.)
     , cumul_dist_(0.)
     , threshold_(copy.threshold_)
 {
@@ -863,9 +865,12 @@ void GrowthCone::make_move(const std::vector<double> &directions_weights,
                     move_.angle  = new_angle;
 
                     cumul_dist_ += move_.module;
+                    cumul_angle_ += delta_angle_;
 
                     // send the new segment to the space manager
-                    if (cumul_dist_ > threshold_)
+                    // this happens either if we cross the distance threshold
+                    // of if it looks like the GC is about to turn too far
+                    if (cumul_dist_ > threshold_ or cumul_angle_ > 0.5*M_PI)
                     {
                         try
                         {
@@ -901,6 +906,7 @@ void GrowthCone::make_move(const std::vector<double> &directions_weights,
                             }
 
                             cumul_dist_ = 0.;
+                            cumul_angle_ = 0.;
                         }
                         catch (...)
                         {

--- a/src/elements/GrowthCone.cpp
+++ b/src/elements/GrowthCone.cpp
@@ -526,116 +526,152 @@ void GrowthCone::retraction(double distance, stype cone_n, int omp_id)
     // remove the points
     double distance_done;
 
-    while (distance > 0 and branch_->size() > 1)
+    // start with the steps that did not yet lead to a polygon
+    BPoint old_pos = branch_->get_last_xy();
+    double free_distance = bg::distance(position_, old_pos);
+
+    if (free_distance >= distance)
     {
-        distance_done    = branch_->get_last_segment_length();
-        BPolygonPtr poly = branch_->get_last_segment();
-        BBox box;
-        ObjectInfo info;
+        // we are still away from the last polygon, in the "free" zone
+        // update cumul_dist and set new position 
+        cumul_dist_ = free_distance - distance;
 
-        if (poly != nullptr)
+        set_position(BPoint(
+            (distance*old_pos.x() + (free_distance - distance)*position_.x())
+            / free_distance,
+            (distance*old_pos.y() + (free_distance - distance)*position_.y())
+            / free_distance));
+
+        // set angle
+        cumul_angle_ = atan2(position_.y() - old_pos.y(),
+                            position_.x() - old_pos.x());
+
+        move_.angle = cumul_angle_;
+        old_angle_  = cumul_angle_;
+
+        distance = 0.;
+    }
+    else
+    {
+        // we go back the whole distance to the last point on the branch
+        position_ = old_pos;
+        cumul_dist_ = 0.;
+        cumul_angle_ = 0.;
+        distance -= free_distance;
+
+        // continue with the polygons
+        while (distance > 0 and branch_->size() > 1)
         {
-            box = bg::return_envelope<BBox>(*(poly.get()));
-            // there is one less segment than point, so size - 2 for segment
-            info = std::make_tuple(neuron_id_, neurite_name_, get_node_id(),
-                                   branch_->size() - 2);
-        }
+            distance_done    = branch_->get_last_segment_length();
+            BPolygonPtr poly = branch_->get_last_segment();
+            BBox box;
+            ObjectInfo info;
 
-        double remaining = distance_done - distance;
-
-        if (remaining < 1e-6) // distance is greater than what we just did
-        {
-            distance -= distance_done;
-            branch_->retract();
-
-            // we also remove the tree box
             if (poly != nullptr)
             {
-                kernel().space_manager.remove_object(box, info, omp_id);
+                box = bg::return_envelope<BBox>(*(poly.get()));
+                // there is one less segment than point, so size - 2 for segment
+                info = std::make_tuple(neuron_id_, neurite_name_, get_node_id(),
+                                       branch_->size() - 2);
             }
-        }
-        else
-        {
-            BPoint p1 = branch_->xy_at(branch_->size() - 2);
-            BPoint p2 = branch_->get_last_xy();
 
-            double new_x =
-                (p2.x() * remaining + p1.x() * (distance_done - remaining)) /
-                distance_done;
-            double new_y =
-                (p2.y() * remaining + p1.y() * (distance_done - remaining)) /
-                distance_done;
+            double remaining = distance_done - distance;
 
-            BPoint new_p = BPoint(new_x, new_y);
-
-            branch_->retract();
-
-            // we remove the previous object and add the new, shorter one
-            if (poly != nullptr)
+            if (remaining < 1e-6) // distance is greater than what we just did
             {
-                try
+                distance -= distance_done;
+                branch_->retract();
+
+                // we also remove the tree box
+                if (poly != nullptr)
                 {
                     kernel().space_manager.remove_object(box, info, omp_id);
                 }
-                catch (...)
+            }
+            else
+            {
+                BPoint p1 = branch_->xy_at(branch_->size() - 2);
+                BPoint p2 = branch_->get_last_xy();
+
+                double new_x =
+                    (p2.x() * remaining + p1.x() * (distance_done - remaining))
+                    / distance_done;
+                double new_y =
+                    (p2.y() * remaining + p1.y() * (distance_done - remaining))
+                    / distance_done;
+
+                BPoint new_p = BPoint(new_x, new_y);
+
+                branch_->retract();
+
+                // we remove the previous object and add the new, shorter one
+                if (poly != nullptr)
                 {
-                    std::throw_with_nested(std::runtime_error(
-                        "Passed from `GrowthCone::retract`, coming from "
-                        "space_manager::remove_object."));
+                    try
+                    {
+                        kernel().space_manager.remove_object(box, info, omp_id);
+                    }
+                    catch (...)
+                    {
+                        std::throw_with_nested(std::runtime_error(
+                            "Passed from `GrowthCone::retract`, coming from "
+                            "space_manager::remove_object."));
+                    }
+
+                    try
+                    {
+                        kernel().space_manager.add_object(
+                            p1, new_p, get_diameter(), remaining,
+                            own_neurite_->get_taper_rate(), info, branch_,
+                            omp_id);
+                    }
+                    catch (...)
+                    {
+                        std::throw_with_nested(std::runtime_error(
+                            "Passed from `GrowthCone::retract` coming from "
+                            "space_manager::add_object (after retraction)."));
+                    }
                 }
 
-                try
-                {
-                    kernel().space_manager.add_object(
-                        p1, new_p, get_diameter(), remaining,
-                        own_neurite_->get_taper_rate(), info, branch_, omp_id);
-                }
-                catch (...)
-                {
-                    std::throw_with_nested(std::runtime_error(
-                        "Passed from `GrowthCone::retract` coming from "
-                        "space_manager::add_object (after retraction)."));
-                }
+                distance = 0.;
+            }
+        }
+
+        // set the new growth cone angle
+        stype last = branch_->size();
+        double x0, y0, x1, y1;
+        BPoint p;
+
+        if (last > 0)
+        {
+            p  = branch_->xy_at(last - 1);
+            x1 = p.x();
+            y1 = p.y();
+
+            if (last > 1)
+            {
+                p  = branch_->xy_at(last - 2);
+                x0 = p.x();
+                y0 = p.y();
+            }
+            else
+            {
+                p  = TopologicalNode::get_position();
+                x0 = p.x();
+                y0 = p.y();
             }
 
-            distance = 0.;
+            move_.angle = atan2(y1 - y0, x1 - x0);
+            old_angle_  = move_.angle;
         }
-    }
 
-    // set the new growth cone angle
-    stype last = branch_->size();
-    double x0, y0, x1, y1;
-    BPoint p;
+        set_position(branch_->get_last_xy());
 
-    if (last > 0)
-    {
-        p  = branch_->xy_at(last - 1);
-        x1 = p.x();
-        y1 = p.y();
-
-        if (last > 1)
+        // prune growth cone if necessary
+        if (branch_->size() == 1)
         {
-            p  = branch_->xy_at(last - 2);
-            x0 = p.x();
-            y0 = p.y();
+            prune(cone_n);
         }
-        else
-        {
-            p  = TopologicalNode::get_position();
-            x0 = p.x();
-            y0 = p.y();
-        }
-
-        move_.angle = atan2(y1 - y0, x1 - x0);
-        old_angle_  = move_.angle;
-    }
-
-    set_position(branch_->get_last_xy());
-
-    // prune growth cone if necessary
-    if (branch_->size() == 1)
-    {
-        prune(cone_n);
     }
 
     // check if we changed area
@@ -891,8 +927,7 @@ void GrowthCone::make_move(const std::vector<double> &directions_weights,
                             {
                                 // move took several step, query old position
                                 // and compute distance
-                                BPoint old_pos = branch_->xy_at(
-                                    branch_->size() - 1);
+                                BPoint old_pos = branch_->get_last_xy();
 
                                 double step_size = bg::distance(old_pos, p);
 

--- a/src/elements/GrowthCone.hpp
+++ b/src/elements/GrowthCone.hpp
@@ -96,8 +96,9 @@ class GrowthCone : public TopologicalNode,
     double scale_up_move_;   // maximal height that GC can cross upwards
     double retraction_time_;
     double old_angle_;
-    double cumul_dist_;  // cumulative distance since last call to add_object
-    double threshold_;   // threshold above which add_object is called
+    double cumul_angle_;  // cumulative angle since last call to add_object
+    double cumul_dist_;   // cumulative distance since last call to add_object
+    double threshold_;    // threshold above which add_object is called
 
     space_tree_map current_neighbors_;
 

--- a/src/elements/GrowthCone.hpp
+++ b/src/elements/GrowthCone.hpp
@@ -96,6 +96,8 @@ class GrowthCone : public TopologicalNode,
     double scale_up_move_;   // maximal height that GC can cross upwards
     double retraction_time_;
     double old_angle_;
+    double cumul_dist_;  // cumulative distance since last call to add_object
+    double threshold_;   // threshold above which add_object is called
 
     space_tree_map current_neighbors_;
 
@@ -140,15 +142,18 @@ class GrowthCone : public TopologicalNode,
     virtual void
     compute_direction_probabilities(std::vector<double> &directions_weights,
                                     double substep) = 0;
+    
     void make_move(const std::vector<double> &directions_weights,
                    const std::vector<std::string> &new_pos_area,
                    double &substep, mtPtr rnd_engine, int omp_id);
+
     virtual void select_direction(const std::vector<double> &directions_weights,
                                   mtPtr rnd_engine, double &substep,
                                   double &new_angle,
                                   stype &default_direction) = 0;
 
     double check_retraction(double substep, mtPtr rnd_engine);
+
     void change_sensing_angle(double angle);
 
     // extension

--- a/src/elements/Neurite.cpp
+++ b/src/elements/Neurite.cpp
@@ -908,11 +908,9 @@ bool Neurite::growth_cone_split(GCPtr branching_cone, double new_length,
 {
     if (not branching_cone->is_dead() and active_)
     {
-
-
         double direction = branching_cone->move_.angle;
 
-        // prepare growth cone variables for split
+        // prepare growth cone for split
         branching_cone->prepare_for_split();
 
         // create new node as branching point

--- a/src/kernel/kernel_manager.cpp
+++ b/src/kernel/kernel_manager.cpp
@@ -93,6 +93,7 @@ KernelManager::KernelManager()
     , num_objects_(0)
     , num_created_objects_(0)
     , adaptive_timestep_(-1.)
+    , add_object_threshold_(0.1)
     , version_("0.1.0")
 {
 }
@@ -163,6 +164,8 @@ const statusMap KernelManager::get_status() const
     set_param(status, "environment_required", env_required_, "");
     set_param(status, "record_enabled", record_enabled_, "");
     set_param(status, "adaptive_timestep", adaptive_timestep_, "");
+    set_param(status, "growth_threshold_polygon", add_object_threshold_,
+              "micrometer");
 
     // set_param(status, "simulation_ID", simulation_ID_);
     /*
@@ -232,6 +235,9 @@ void KernelManager::set_status(const statusMap &status)
     bool env_required_old = env_required_;
     bool env_updated = get_param(status, "environment_required", env_required_);
 
+    bool threshupdate = get_param(status, "growth_threshold_polygon",
+                                  add_object_threshold_);
+
     /*
      * delegate the rest; no set_status for:
      * - rng_manager
@@ -247,9 +253,15 @@ void KernelManager::set_status(const statusMap &status)
     env_updated *= (env_required_old != env_required_);
     at_updated  *= (at_old != adaptive_timestep_);
 
-    if (env_updated or at_updated)
+    if (env_updated or at_updated or threshupdate)
     {
         neuron_manager.update_kernel_variables();
     }
 }
+
+double KernelManager::get_add_object_threshold() const
+{
+    return add_object_threshold_;
+}
+
 } // namespace growth

--- a/src/kernel/kernel_manager.hpp
+++ b/src/kernel/kernel_manager.hpp
@@ -104,9 +104,11 @@ class KernelManager
 
     std::string simulation_ID_;
     double get_adaptive_timestep() const;
+    double get_add_object_threshold() const;
     bool using_environment() const;
     //! Returns true if kernel is initialized
     bool is_initialized() const;
+
     //! Space manager instance
     ParallelismManager parallelism_manager;
     RNGManager rng_manager;
@@ -126,6 +128,7 @@ class KernelManager
     stype num_objects_;         //!< current number of objects
     std::string version_;
     double adaptive_timestep_; //! if > 1, step divider when interacting
+    double add_object_threshold_;
 };
 
 KernelManager &kernel();


### PR DESCRIPTION
This PR make the addition of new polygons to model the neurite growth progressive: a growth cone has to get a certain distance (given by ``"growth_threshold_polygon"``) before a new polygon is added.
Alternatively, the polygon is also added if the cumulative angle reaches 90° to prevent issues.

The PR also document the ``"print_progress"`` option.