### PR TITLE
Fix bug in retraction with null module or length 1 branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
          if: ${{ matrix.os == 'macos-latest' }}
          run: |
            rm -rf /usr/local/bin/2to3
-           brew unlink gcc gcc@8 gcc@9 gcc@10
+           brew unlink gcc gcc@8 gcc@9
            chmod +x extra/install_macos.sh
            cd extra
            ./install_macos.sh

--- a/extra/install_macos.sh
+++ b/extra/install_macos.sh
@@ -6,6 +6,8 @@ brew tap homebrew/core
 
 brew install gcc@10 cmake python3 geos doxygen boost libomp
 
+brew link gcc@10
+
 pip3 install setuptools
 pip3 install cython
 pip3 install numpy scipy pint pyneuroml

--- a/src/elements/GrowthCone.cpp
+++ b/src/elements/GrowthCone.cpp
@@ -406,7 +406,7 @@ void GrowthCone::grow(mtPtr rnd_engine, stype cone_n, double substep)
                 // we elongated so we did not just get out of a retraction
                 just_retracted_ = false;
             }
-            else
+            else if (move_.module < 0)
             {
                 // =========== //
                 // Back we go! //
@@ -414,6 +414,11 @@ void GrowthCone::grow(mtPtr rnd_engine, stype cone_n, double substep)
 
                 // retracting distance is the opposite of the (negative module)
                 retraction(-move_.module, cone_n, omp_id);
+            }
+            else
+            {
+                // either the local substep was zero or we stopped
+                stopped_ = local_substep == 0 ? stopped_ : true;
             }
         }
 
@@ -526,9 +531,10 @@ void GrowthCone::retraction(double distance, stype cone_n, int omp_id)
     // remove the points
     double distance_done, inv_dist;
 
-    // start with the steps that did not yet lead to a polygon
-    BPoint current_pos, old_pos(branch_->get_last_xy());
+    // initialize current_pos and old_pos
+    BPoint current_pos(position_), old_pos(branch_->get_last_xy());
 
+    // start with the steps that did not yet lead to a polygon
     if (cumul_dist_ > distance)
     {
         // we are still away from the last polygon, in the "free" zone


### PR DESCRIPTION
This PR corrects the behavior of ``GrowthCone::retraction`` when the module is zero (the function is no longer called) and when the retracting branch has length 1 (proper initialization of ``current_pos``).