### PR TITLE
Improved SWC I/O

### DIFF
--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -21,7 +21,7 @@ script which should provide a convenient multiplatform experience, made even
 easier by the automatic install scripts available on most platforms.
 
 **NB** if you run against some bugs after the installation, please first have
-a look at the `Known errors`_ section, in case it is not already listed there.
+a look at the "Known errors" section, in case it is not already listed there.
 
 
 .. contents:: :depth: 2

--- a/src/growth.cpp
+++ b/src/growth.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
     growth::SkelNeurite axon, dendrites, nodes, growth_cones, somas;
     std::vector<growth::stype> gid = {0};
     // growth::get_skeleton(axon, dendrites, nodes, growth_cones, somas, gid);
-    growth::get_swc_("myswc", gid, 10);
+    growth::get_swc_("myswc", gid, 10, false);
 
     return 0;
 }

--- a/src/io/Swc.cpp
+++ b/src/io/Swc.cpp
@@ -31,6 +31,10 @@ namespace growth
 
 typedef std::array<std::vector<double>, 3> PointsArray;
 
+
+Swc::Swc()
+{}
+
 /**
  * @brief Create a file with neuron in SWC format
  *
@@ -48,6 +52,21 @@ Swc::Swc(std::string output_file, unsigned int resolution)
     swc_file_.open(output_file);
     swc_file_ << "#SWC file properties\n";
     swc_file_ << "#sample element_ID X Y Z radius parent\n";
+}
+
+Swc::Swc(Swc&& rhs) :
+    resolution_(std::move(rhs.resolution_))
+{
+    swc_file_.swap(rhs.swc_file_);
+}
+
+
+Swc& Swc::operator=(Swc &&rhs)
+{
+    resolution_ = rhs.resolution_;
+    swc_file_.swap(rhs.swc_file_);
+
+    return *this;
 }
 
 

--- a/src/io/Swc.hpp
+++ b/src/io/Swc.hpp
@@ -49,7 +49,10 @@ class Swc
     unsigned int resolution_;
 
   public:
+    Swc();
     Swc(std::string output_file, unsigned int resolution);
+    Swc(Swc&& rhs);
+    Swc& operator=(Swc &&rhs);
     void to_swc(const Neuron *, stype gid);
     void close_file();
     ~Swc();

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -914,19 +914,40 @@ void get_distances_(stype gid, const std::string &neurite_name, stype node,
 
 
 void get_swc_(std::string output_file, std::vector<stype> gids,
-              unsigned int resolution)
+              unsigned int resolution, bool split)
 {
     std::sort(gids.begin(), gids.end());
-    Swc swc(output_file, resolution);
+    Swc swc;
+
+    if (not split)
+    {
+        Swc tmp(output_file + ".swc", resolution);
+        swc = std::move(tmp);
+    }
 
     for (const auto &neuron_gid : gids)
     {
+        if (split)
+        {
+            Swc tmp(output_file + "_" + std::to_string(neuron_gid) + ".swc",
+                    resolution);
+            swc = std::move(tmp);
+        }
+
         const NeuronPtr neuron = kernel().neuron_manager.get_neuron(neuron_gid);
-        // @todo: pass non default arguments
+
         swc.to_swc(neuron.get(), neuron_gid);
+
+        if (split)
+        {
+            swc.close_file();
+        }
     }
 
-    swc.close_file();
+    if (not split)
+    {
+        swc.close_file();
+    }
 }
 
 

--- a/src/module.hpp
+++ b/src/module.hpp
@@ -136,7 +136,7 @@ void get_skeleton_(SkelNeurite &axon, SkelNeurite &dendrites,
 
 
 void get_swc_(std::string output_file, std::vector<stype> gids,
-              unsigned int resolution);
+              unsigned int resolution, bool split);
 
 
 statusMap get_kernel_status_();

--- a/src/pymodule/dense/_pygrowth.pxd.in
+++ b/src/pymodule/dense/_pygrowth.pxd.in
@@ -161,7 +161,7 @@ cdef extern from "../module.hpp" namespace "growth":
                              double &dist_to_soma) except +
 
     cdef void get_swc_(string output_file,
-        vector[stype] gids, unsigned int resolution) except +
+        vector[stype] gids, unsigned int resolution, bool split) except +
 
     cdef statusMap get_status_(stype gid) except +
 

--- a/src/pymodule/dense/_pygrowth.pyx
+++ b/src/pymodule/dense/_pygrowth.pyx
@@ -2045,8 +2045,10 @@ def _neuron_to_swc(filename, gid=None, resolution=10, split=False):
     split : bool
         Split neurons among files if there are more than one neuron.
     '''
+    filename = filename[:-4] if filename.endswith(".swc") else filename
+
     cdef:
-        string cfname = _to_bytes(filename.rstrip(".swc"))
+        string cfname = _to_bytes(filename)
         vector[stype] gids
 
     if gid is None:

--- a/src/pymodule/dense/_pygrowth.pyx
+++ b/src/pymodule/dense/_pygrowth.pyx
@@ -2029,7 +2029,7 @@ def _get_parent_and_soma_distances(neuron, neurite, node, segment):
     return distance_to_parent, distance_to_soma
 
 
-def _neuron_to_swc(filename, gid=None, resolution=10):
+def _neuron_to_swc(filename, gid=None, resolution=10, split=False):
     '''
     Save neurons to SWC file.
 
@@ -2042,10 +2042,13 @@ def _neuron_to_swc(filename, gid=None, resolution=10):
     resolution : int, optional (default: 10)
         Coarse-graining factor of the structure: only one point every
         `resolution` will be kept.
+    split : bool
+        Split neurons among files if there are more than one neuron.
     '''
     cdef:
-        string cfname = _to_bytes(filename)
+        string cfname = _to_bytes(filename.rstrip(".swc"))
         vector[stype] gids
+
     if gid is None:
         gids = get_neurons_()
     elif isinstance(gid, int):
@@ -2053,7 +2056,10 @@ def _neuron_to_swc(filename, gid=None, resolution=10):
     else:
         for n in gid:
             gids.push_back(<stype>n)
-    get_swc_(cfname, gids, resolution)
+
+    split *= (gids.size() > 1)
+
+    get_swc_(cfname, gids, resolution, split)
 
 
 def _get_tree(neuron, neurite):

--- a/src/pymodule/dense/io/__init__.py
+++ b/src/pymodule/dense/io/__init__.py
@@ -20,7 +20,10 @@
 # along with DeNSE. If not, see <http://www.gnu.org/licenses/>.
 
 
-""" IO functions """
+"""
+IO functions
+============
+"""
 
 import hashlib
 import json

--- a/src/pymodule/dense/io/dataIO.py
+++ b/src/pymodule/dense/io/dataIO.py
@@ -79,7 +79,7 @@ def save_to_neuroml(filename, gid=None, resolution=10):
     '''
     Save the morphology of each neuron to a single NeuroML file.
 
-    NeuroML is an XML (Extensible Markup Language) based model description
+    NeuroML is an XML (eXtensible Markup Language) based model description
     language that aims to provide a common data format for defining and
     exchanging models in computational neuroscience.  It is focused on
     biophysical and anatomical detailed models.
@@ -94,6 +94,10 @@ def save_to_neuroml(filename, gid=None, resolution=10):
     resolution : int, optional (default: 10)
         Subsampling coefficient for points on a neurite (sample on point every
         `resolution`).
+
+    See also
+    --------
+    :func:`~dense.io.save_to_swc`
     '''
     import neuroml
     import neuroml.writers as writers

--- a/src/pymodule/dense/io/data_swc.py
+++ b/src/pymodule/dense/io/data_swc.py
@@ -60,7 +60,9 @@ def save_to_swc(filename, gid=None, resolution=10, split=False):
     Parameters
     ----------
     filename : str
-        Name of the SWC to write.
+        Name of the SWC file to write.
+        If `split` is True, it will be combined with the neurons' gids to form
+        each final filename.
     gid : int or list of ints
         Neurons to save.
     resolution : int, optional (default: 10)
@@ -69,10 +71,13 @@ def save_to_swc(filename, gid=None, resolution=10, split=False):
     split : bool, optional (default: False)
         Whether the neurons should be stored into a single SWC file or each into
         its own SWC file (ignored if `gid` contains only one neuron).
+        If `split` is True, the gid of the neurons will automatically be
+        appended to `filename` to make each idenpendent SWC file.
 
     See also
     --------
-    :func:`~dense.io.save_to_neuroml`` for NeuroML format.
+    :func:`~dense.io.load_swc` to load SWC data.
+    :func:`~dense.io.save_to_neuroml` for NeuroML format.
     '''
     if isinstance(gid, (int, Neuron)):
         gid = [gid]
@@ -83,8 +88,9 @@ def save_to_swc(filename, gid=None, resolution=10, split=False):
 
 def load_swc(swc_path, info=None):
     """
-    Import SWC files as a :class:`~dense.elements.Population`.
-    SWC data will be automatically loading from the file given by `swc_path`
+    Import SWC files as a :class:`~dense.elements.Neuron` or a
+    :class:`~dense.elements.Population`.
+    SWC data will be automatically loaded from the file given by `swc_path`
     or from all SWC file inside `swc_path` if it is a folder.
 
     Parameters
@@ -92,12 +98,16 @@ def load_swc(swc_path, info=None):
     swc_path: str
         Path to a file or folder containing SWC information to load.
     info : str, optional (default: None)
-        JSON file containing additional information about the neurons.
+        Optional JSON file containing additional information about the neurons.
 
     Returns
     -------
-    A :class:`~dense.Neuron` if a single neuron is concerned or a
-    :class:`~dense.Population` object if several neurons are involved.
+    a :class:`~dense.element.Neuron` if a single neuron is concerned or
+    a :class:`~dense.Population` object if several neurons are involved.
+
+    See also
+    --------
+    :func:`~dense.io.save_to_swc` to neurons as SWC data.
     """
     data = None
 
@@ -108,15 +118,12 @@ def load_swc(swc_path, info=None):
     else:
         data = _neurons_from_swc_folder(swc_path, info=info)
 
+    pop = Population.from_swc(data, info)
+
     if len(data) == 1:
-        gid = next(iter(data))
-        neuron = data[gid]
+        return next(iter(pop))
 
-        return Neuron(gid, position=neuron["position"],
-                      soma_radius=neuron["soma_radius"],
-                      in_simulator=False)
-
-    return Population.from_swc(data, info)
+    return pop
 
 
 def _neurons_from_swc_folder(path, info):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+# test_io.py
+#
+# This file is part of DeNSE.
+#
+# Copyright (C) 2019 SeNEC Initiative
+#
+# DeNSE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# DeNSE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DeNSE. If not, see <http://www.gnu.org/licenses/>.
+
+
+""" Testing IO functions """
+
+import os
+from os.path import isdir, isfile, join
+
+import numpy as np
+
+import dense as ds
+from dense.units import *
+
+
+def test_swc():
+    '''
+    Save neurons as SWC files.
+    '''
+    ds.reset_kernel()
+
+    num_neurons = 5
+
+    rng = np.random.default_rng()
+
+    neuron_params = {"position": rng.uniform(-100, 100, (num_neurons, 2)) * um}
+
+    # create one neuron
+    neurons = ds.create_neurons(num_neurons, neuron_params, num_neurites=2)
+
+    ds.simulate(10.*day)
+
+    # save all neurons into a single file
+    filename = "all_neurons.swc"
+    ds.io.save_to_swc(filename)
+
+    assert isfile(filename)
+
+    swc_neurons = ds.io.load_swc(filename)
+
+    assert len(neurons) == len(swc_neurons)
+
+    for n0, n1 in zip(neurons, swc_neurons):
+        assert int(n0) == int(n1)
+        assert np.isclose(n0.position, n1.position).all()
+        assert n1.axon is not None
+        assert len(n1.dendrites) == 1
+
+    # save all neurons into separate files
+    dirname = "all_neurons"
+
+    try:
+        os.mkdir(dirname)
+    except FileExistsError:
+        pass
+
+    ds.io.save_to_swc(join(dirname, "neuron"), split=True)
+
+    for i in range(num_neurons):
+        fname = join(dirname, "neuron_{}.swc".format(i))
+        assert isfile(fname)
+
+        n = ds.io.load_swc(fname)
+
+        assert int(neurons[i]) == int(n)
+        assert np.isclose(neurons[i].position, n.position).all()
+        assert n.axon is not None
+        assert len(n.dendrites) == 1
+
+    # save two neurons
+    filename = "two_neurons.swc"
+
+    gids = (1, 3)
+
+    ds.io.save_to_swc(filename, gid=gids)
+
+    # save two neurons into separate files
+    dirname = "two_neurons"
+
+    try:
+        os.mkdir(dirname)
+    except FileExistsError:
+        pass
+
+    ds.io.save_to_swc(join(dirname, "neuron"), gid=gids, split=True)
+
+    assert len(os.listdir(dirname)) == len(gids)
+
+    # check the two partial saves
+    for path in (filename, dirname):
+        two_neurons = ds.io.load_swc(path)
+
+        assert len(two_neurons) == len(gids)
+
+        for gid, n in zip(gids, two_neurons):
+            assert int(n) == gid
+            assert np.isclose(neurons[gid].position, n.position).all()
+            assert n.axon is not None
+            assert len(n.dendrites) == 1
+
+
+if __name__ == "__main__":
+    test_swc()


### PR DESCRIPTION
Corrects and simplifies SWC save and load functions.
Only ``save_to_swc`` and ``load_swc`` remain.
Saving and loading now automatically handles multiple neurons in a single file or separate files within a folder.

Fixes #32 (or at least most of it)
Fixes #46