### PR TITLE
Reload and plot neurons from SWC

### DIFF
--- a/docs/dense_theme/static/dense_theme.css
+++ b/docs/dense_theme/static/dense_theme.css
@@ -1,5 +1,19 @@
 @import url("bootstrap-sphinx.css");
 
+@media (prefers-color-scheme: dark) {
+    body {
+        filter: invert(100%) hue-rotate(180deg);
+    }
+
+    html {
+        background-color: #222;
+    }
+
+    img {
+        filter: invert(100%) hue-rotate(180deg);
+    }
+}
+
 
 a.headerlink {
     visibility: hidden;

--- a/docs/user/recording.rst
+++ b/docs/user/recording.rst
@@ -27,12 +27,15 @@ Each unit has different kind of "observables" that can be recorded via a
 recorder.
 To find out what observables are available, you can use:
 
-```python
-neuron.observables                                                    # for a neuron
-neuron.axon.observables                                               # for the axon
-neuron.dendrites["dendrite_1"].observables                            # for a dendrite
-ds.get_object_properties(neuron, "observables", level="growth_cone")  # for a growth cone
-```
+.. code-block:: python
+
+    neuron.observables                                                    # for a neuron
+    neuron.axon.observables                                               # for the axon
+    neuron.dendrites["dendrite_1"].observables                            # for a dendrite
+    ds.get_object_properties(neuron, "observables", level="growth_cone")  # for a growth cone
+
+To be able to plot the recorded information, use the
+:func:`~dense.plot.plot_recording`.
 
 
 Saving neuronal morphologies
@@ -62,4 +65,23 @@ anatomical models.
 Finally :func:`dense.io.save_json_info` is used to save an `info.json` file
 meant to store the simulation configuration.
 
+
+Working with saved data
+=======================
+
+After the data has been saved to disk, you can either load it in other libraries
+reading SWC or NeuroML formats, or reload it in DeNSE.
+
+.. note::
+
+    Apart from DeNSE, most other libraries require the neurons to be split
+    into separate SWC files, so make sure *not* to set `split` to True if you
+    want external compatibility.
+
+You can reload the neurons in DeNSE, then plot them directly via:
+
+.. code-block:: python
+
+    neurons = ds.io.load_swc("file.swc")
+    ds.plot.plot_neurons(neurons, show=True)
 

--- a/docs/user/recording.rst
+++ b/docs/user/recording.rst
@@ -1,55 +1,65 @@
-=======================
-Save simulation results
-=======================
+=========================
+Saving simulation results
+=========================
+
+The processes ocurring during a DeNSE simulation can be monitored, to
+understand what happened during the simulation, and be stored on disk to be
+reused afterwards.
+
+There are mainly two kinds of data you can save, those generated during the
+simulation, which we call "runtime data" or those representing the final state
+at the end of the simulation, or "static data".
 
 
-Recording
-=========
+Recording information
+=====================
 
-The data required to record a branching event is:
-* the GID of the branching neuron
-* the neurite on which the branching happen
-* the time at which it happened (timestep + substep)
+DeNSE enables to record "runtime data", i.e. dynamical information about the
+growth process of neurons or their subprocesses, that occured during the
+simulation, via
+:func:`~dense.create_recorders`.
 
+Recorders will save information about neurons, neurites, or growth cones in
+memory so that it can be plotted after the simulation using
+:func:`~dense.plot.plot_recording`.
 
-Data to SWC format
-==================
+Each unit has different kind of "observables" that can be recorded via a
+recorder.
+To find out what observables are available, you can use:
 
-The data generated from a DeNSE simulation can be stored on your machine to be reused after.
-
-There are mainly two kinds of data you can save, those generated during the simulation, which we call `runtime_data` or those at the end of the simulation `static_data`.
-
-DeNSE offers a set of functions to analyze these data too.
-
-All the `runtime_data` will pass by the
-.. doxygenclass::growth::RecordManager
-at this stage a limited set of information can be stored, it's possible to modify and enhance this module. The main idea is to store all the info during the runtime, being the
-.. doxygenclass::growth::SimulationManager
-calling the `Recorder` for the elongation data or the
-.. doxygenclass::growth::Neurite
-calling the `Recorder` for the branching event data.
-
-Each event requires an identifier since everything is saved to the same file.
-The file will be saved in the current working directory in the path:
-`<SimulationID>/record.dat`
-
-The `static_data` are the `morphology.swc` and `info.json`, both are produced at the end of the simulation, they can be placed where the user prefer, since we do expect these are the data usually required.
-
-For an insight on the SWC format please refer to the `reference page <http://www.neuronland.org/NLMorphologyConverter/MorphologyFormats/SWC/Spec.html>`_. The SWC format is one of the most widely used  neuron morphology formats (in particular, a standardized version of this format is used by the `neuromorpho <http://www.neuromorpho.org>`_ archive).
+```python
+neuron.observables                                                    # for a neuron
+neuron.axon.observables                                               # for the axon
+neuron.dendrites["dendrite_1"].observables                            # for a dendrite
+ds.get_object_properties(neuron, "observables", level="growth_cone")  # for a growth cone
+```
 
 
-DeNSE can also store neuron morphologies in the `NeuroML <https://neuroml.org/>`_ format, an alternative data format for defining and
-    exchanging models in computational neuroscience focused on
-    biophysical and anatomical detailed models.
+Saving neuronal morphologies
+============================
 
-The `info.json` file is meant to store the simulation configuration.    
+After a call to :func:`~dense.simulate`, the state of the neuron (its
+morphology) is a static data that can be stored to file to be processed later.
 
-The functions to deal with data storage are written under the name DataIO.
-
-In order to save data you need to use the function of class "io".
-
-ex.:
+To save simulation information to files, you can use the following functions:
 
 * :func:`dense.io.save_to_swc`
-* :func:`dense.io.save_json_info`
 * :func:`dense.io.save_to_neuroml`
+* :func:`dense.io.save_json_info`
+
+The first two aim at saving morphological information about the neurons to
+disk.
+:func:`dense.io.save_to_swc` uses the SWC format as detailed on this
+`reference page <http://www.neuronland.org/NLMorphologyConverter/MorphologyFormats/SWC/Spec.html>`_.
+SWC is one of the most widely used neuron morphology formats
+(it is used, in particular, by the `neuromorpho <http://www.neuromorpho.org>`_
+archive).
+DeNSE can also store neuron morphologies in the
+`NeuroML <https://neuroml.org/>`_ format, an alternative data format to define
+and exchange models in computational neuroscience, focused on biophysical and
+anatomical models.
+
+Finally :func:`dense.io.save_json_info` is used to save an `info.json` file
+meant to store the simulation configuration.
+
+

--- a/src/growth.cpp
+++ b/src/growth.cpp
@@ -65,8 +65,8 @@ int main(int argc, char **argv)
 
     growth::SkelNeurite axon, dendrites, nodes, growth_cones, somas;
     std::vector<growth::stype> gid = {0};
-    // growth::get_skeleton(axon, dendrites, nodes, growth_cones, somas, gid);
-    growth::get_swc_("myswc", gid, 10, false);
+
+    growth::save_swc_("myswc", gid, 10, false);
 
     return 0;
 }

--- a/src/io/Swc.hpp
+++ b/src/io/Swc.hpp
@@ -53,6 +53,8 @@ class Swc
     Swc(std::string output_file, unsigned int resolution);
     Swc(Swc&& rhs);
     Swc& operator=(Swc &&rhs);
+    stype write_data(BranchPtr b, stype idx, stype &sample, stype last_sample,
+                     int ID, double final_diam, double tap_r, double final_dts);
     void to_swc(const Neuron *, stype gid);
     void close_file();
     ~Swc();

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -913,8 +913,8 @@ void get_distances_(stype gid, const std::string &neurite_name, stype node,
 }
 
 
-void get_swc_(std::string output_file, std::vector<stype> gids,
-              unsigned int resolution, bool split)
+void save_swc_(std::string output_file, std::vector<stype> gids,
+               unsigned int resolution, bool split)
 {
     std::sort(gids.begin(), gids.end());
     Swc swc;

--- a/src/module.hpp
+++ b/src/module.hpp
@@ -135,8 +135,8 @@ void get_skeleton_(SkelNeurite &axon, SkelNeurite &dendrites,
                    unsigned int resolution);
 
 
-void get_swc_(std::string output_file, std::vector<stype> gids,
-              unsigned int resolution, bool split);
+void save_swc_(std::string output_file, std::vector<stype> gids,
+               unsigned int resolution, bool split);
 
 
 statusMap get_kernel_status_();

--- a/src/pymodule/dense/_pygrowth.pxd.in
+++ b/src/pymodule/dense/_pygrowth.pxd.in
@@ -160,8 +160,8 @@ cdef extern from "../module.hpp" namespace "growth":
                              stype segment, double &dist_to_parent,
                              double &dist_to_soma) except +
 
-    cdef void get_swc_(string output_file,
-        vector[stype] gids, unsigned int resolution, bool split) except +
+    cdef void save_swc_(string output_file, vector[stype] gids,
+                        unsigned int resolution, bool split) except +
 
     cdef statusMap get_status_(stype gid) except +
 

--- a/src/pymodule/dense/_pygrowth.pyx
+++ b/src/pymodule/dense/_pygrowth.pyx
@@ -2061,7 +2061,7 @@ def _neuron_to_swc(filename, gid=None, resolution=10, split=False):
 
     split *= (gids.size() > 1)
 
-    get_swc_(cfname, gids, resolution, split)
+    save_swc_(cfname, gids, resolution, split)
 
 
 def _get_tree(neuron, neurite):

--- a/src/pymodule/dense/elements.py
+++ b/src/pymodule/dense/elements.py
@@ -806,7 +806,7 @@ class Branch(object):
             return self._r
         else:
             assert (isinstance(self._r.m, _np.ndarray)), \
-                "branch's norm is not an array, there is a mistake"
+                "branch's radius is not an array, there is a mistake"
             return self._r
 
     @property

--- a/src/pymodule/dense/morphology/graph.py
+++ b/src/pymodule/dense/morphology/graph.py
@@ -194,6 +194,10 @@ class SpatialMultiNetwork(object):
         else:
             raise KeyError("SpatialNetwork has no edge " + str(edge) + ".")
 
+    def has_edge(self, edge):
+        ''' Return True if the edge is in the graph, else False '''
+        return edge in self._edges
+
     @property
     def population(self):
         ''' The neuronal population '''
@@ -459,9 +463,9 @@ class SpatialNetwork(_BaseNetwork):
         if target not in self._nodes:
             raise ValueError("There is no node {}.".format(target))
 
-        if edge not in self._edges:
+        if not self.has_edge(edge):
             super().new_edge(
-                self, source, target, attributes=attributes, **kwargs)
+                source, target, attributes=attributes, **kwargs)
         else:
             if not self._multigraph:
                 raise RuntimeError("Trying to add existing edge.")

--- a/src/pymodule/dense/plot/plot_structures.py
+++ b/src/pymodule/dense/plot/plot_structures.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with DeNSE. If not, see <http://www.gnu.org/licenses/>.
 
-""" Plot recording """
+""" Plot structures (neurons, dendrograms...) """
 
 from collections import deque
 
@@ -34,6 +34,7 @@ import numpy as np
 from .. import _pygrowth as _pg
 from .._helpers import is_iterable
 from ..environment import plot_shape
+from ..elements import Population, Neuron
 from ..units import *
 from .plot_utils import *
 
@@ -155,14 +156,45 @@ def plot_neurons(gid=None, mode="sticks", show_nodes=False, show_active_gc=True,
     axon_lines, dend_lines = None, None
     axons, dendrites = None, None
 
-    if mode in ("lines", "mixed"):
-        somas, axon_lines, dend_lines, growth_cones, nodes = \
-            _pg._get_pyskeleton(gid, subsample)
-    if mode in ("sticks", "mixed"):
-        axons, dendrites, somas = _pg._get_geom_skeleton(gid)
+    if isinstance(gid, Population) and not list(gid._in_simulator.values())[0]:
+        somas = np.array([v.m for v in gid.position.values()]).T
+
+        somas = np.vstack((somas, [v.m for v in gid.soma_radius.values()]))
+
+        axon_lines, dend_lines = [[], []], [[], []]
+        for n in gid:
+            points = n.axon.xy.m
+
+            for i in (0, 1):
+                axon_lines[i].extend(points[:, i])
+                axon_lines[i].append(np.NaN)
+
+            for d in n.dendrites.values():
+                points = d.xy.m
+
+                for i in (0, 1):
+                    dend_lines[i].extend(points[:, i])
+                    dend_lines[i].append(np.NaN)
+
+        show_active_gc = False
+    elif isinstance(gid[0], Neuron) and not gid[0]._in_simulator:
+        somas = [n.soma_radius for n in gid]
+        
+        axon_lines = np.concatenate([n.axon.xy.m.T for n in gid]).T
+        dend_lines = np.concatenate(
+            [d.xy.m.T for n in gid for d in n.dendrites.values()]).T
+
+        show_active_gc = False
+    else:
+        if mode in ("lines", "mixed"):
+            somas, axon_lines, dend_lines, growth_cones, nodes = \
+                _pg._get_pyskeleton(gid, subsample)
+        if mode in ("sticks", "mixed"):
+            axons, dendrites, somas = _pg._get_geom_skeleton(gid)
 
     # get the culture if necessary
     env_required = _pg.get_kernel_status('environment_required')
+
     if show_culture and env_required:
         if culture is None:
             culture = _pg.get_environment()
@@ -211,8 +243,10 @@ def plot_neurons(gid=None, mode="sticks", show_nodes=False, show_active_gc=True,
     for i, x, y, r in zip(gid, somas[0], somas[1], radii):
         circle = plt.Circle(
             (x, y), r, color=soma_color, alpha=soma_alpha)
+
         artist = ax.add_artist(circle)
         artist.set_zorder(5)
+
         if show_neuron_id:
             str_id = str(i)
             xoffset = len(str_id)*0.35*size
@@ -224,9 +258,18 @@ def plot_neurons(gid=None, mode="sticks", show_nodes=False, show_active_gc=True,
 
     # set the axis limits
     if (not show_culture or not env_required) and len(ax.lines) == new_lines:
+        xs, ys = [], []
+
+        if axon_lines is not None:
+            xs.extend(axon_lines[0])
+            ys.extend(axon_lines[1])
+
+        if dend_lines is not None:
+            xs.extend(dend_lines[0])
+            ys.extend(dend_lines[1])
+
         if mode in ("lines", "mixed"):
-            _set_ax_lim(ax, axon_lines[0] + dend_lines[0],
-                        axon_lines[1] + dend_lines[1], offset=2*r_max)
+            _set_ax_lim(ax, xs, ys, offset=2*r_max)
         else:
             xx = []
             yy = []

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -46,11 +46,11 @@ def test_swc():
     # create one neuron
     neurons = ds.create_neurons(num_neurons, neuron_params, num_neurites=2)
 
-    ds.simulate(10.*day)
+    ds.simulate(1.*day)
 
     # save all neurons into a single file
     filename = "all_neurons.swc"
-    ds.io.save_to_swc(filename)
+    ds.io.save_to_swc(filename, split=False)
 
     assert isfile(filename)
 
@@ -72,7 +72,7 @@ def test_swc():
     except FileExistsError:
         pass
 
-    ds.io.save_to_swc(join(dirname, "neuron"), split=True)
+    ds.io.save_to_swc(join(dirname, "neuron.swc"), resolution=1)
 
     for i in range(num_neurons):
         fname = join(dirname, "neuron_{}.swc".format(i))
@@ -84,13 +84,14 @@ def test_swc():
         assert np.isclose(neurons[i].position, n.position).all()
         assert n.axon is not None
         assert len(n.dendrites) == 1
+        assert np.all(np.isclose(n.axon.xy.m, neurons[i].axon.xy.m))
 
     # save two neurons
     filename = "two_neurons.swc"
 
     gids = (1, 3)
 
-    ds.io.save_to_swc(filename, gid=gids)
+    ds.io.save_to_swc(filename, gid=gids, resolution=1, split=False)
 
     # save two neurons into separate files
     dirname = "two_neurons"
@@ -100,7 +101,7 @@ def test_swc():
     except FileExistsError:
         pass
 
-    ds.io.save_to_swc(join(dirname, "neuron"), gid=gids, split=True)
+    ds.io.save_to_swc(join(dirname, "neuron.swc"), gid=gids, resolution=1)
 
     assert len(os.listdir(dirname)) == len(gids)
 
@@ -115,6 +116,7 @@ def test_swc():
             assert np.isclose(neurons[gid].position, n.position).all()
             assert n.axon is not None
             assert len(n.dendrites) == 1
+            assert np.all(np.isclose(neurons[gid].axon.xy.m, n.axon.xy.m))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR enables to reload neurons from SWC files into a valid ``Population`` object with ``Neuron`` objects that can be used in the `plot_neurons` function.

It also renames the ``get_swc_`` C++ function into ``save_swc_`` (though it should not be a problem because no 

As a minor note, it also:
* improves NNGT compatibility
* improves the documentation (including dark mode)